### PR TITLE
docs: add desktop release runbook

### DIFF
--- a/docs/admin/01-deploy.md
+++ b/docs/admin/01-deploy.md
@@ -4,7 +4,7 @@ RAILWISE Desktop 支持公网分发、共享 NAS 分发和企业内网私有更�
 
 ## 公网分发
 
-使用 GitHub Actions 的桌面发布流程构建 macOS、Windows、Linux 安装包。发布产物上传到 Release 和对象存储，更新元数据由 `updates.railwise.cn` 返回。
+使用 GitHub Actions 的 `Desktop Release` 流程构建 macOS、Windows、Linux 安装包。发布产物上传到 Release 和对象存储，更新元数据由 `updates.railwise.cn` 返回。签名 secrets 和触发步骤见 `docs/admin/06-desktop-release-runbook.md`。
 
 ## 共享 NAS 分发
 

--- a/docs/admin/06-desktop-release-runbook.md
+++ b/docs/admin/06-desktop-release-runbook.md
@@ -1,0 +1,138 @@
+# Desktop Release Runbook
+
+本文档用于管理员配置并执行 RAILWISE Desktop 的 GitHub Actions 发布流程。发布流程会构建 Windows、macOS Apple Silicon、macOS Intel 和 Linux 安装包，并创建 draft GitHub Release。
+
+## 前置权限
+
+执行人需要具备以下权限：
+
+- GitHub 仓库 `Actions: write` 与 `Contents: write`
+- GitHub 仓库 secrets 管理权限
+- Apple Developer 账号及 Developer ID Application 证书
+- SignPath 项目访问权限
+- Tauri updater 签名私钥
+
+## 必需 Secrets
+
+全平台必需：
+
+```text
+TAURI_SIGNING_PRIVATE_KEY
+TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+```
+
+macOS 必需：
+
+```text
+APPLE_CERTIFICATE
+APPLE_CERTIFICATE_PASSWORD
+APPLE_KEYCHAIN_PASSWORD
+APPLE_ID
+APPLE_ID_PASSWORD
+APPLE_TEAM_ID
+APPLE_SIGNING_IDENTITY
+```
+
+Windows 必需：
+
+```text
+SIGNPATH_API_TOKEN
+SIGNPATH_ORG_ID
+```
+
+当前 workflow 会在构建前执行 secret preflight。缺失任意必需项时，job 会在 `Validate release secrets` 步骤失败，并列出缺失名称。
+
+## 配置方式
+
+使用 GitHub CLI 配置 secrets：
+
+```bash
+gh secret set TAURI_SIGNING_PRIVATE_KEY --repo railwise-cn/RAILWISE-CLI < tauri-private-key.pem
+gh secret set TAURI_SIGNING_PRIVATE_KEY_PASSWORD --repo railwise-cn/RAILWISE-CLI
+gh secret set APPLE_CERTIFICATE --repo railwise-cn/RAILWISE-CLI < certificate.p12.base64
+gh secret set APPLE_CERTIFICATE_PASSWORD --repo railwise-cn/RAILWISE-CLI
+gh secret set APPLE_KEYCHAIN_PASSWORD --repo railwise-cn/RAILWISE-CLI
+gh secret set APPLE_ID --repo railwise-cn/RAILWISE-CLI
+gh secret set APPLE_ID_PASSWORD --repo railwise-cn/RAILWISE-CLI
+gh secret set APPLE_TEAM_ID --repo railwise-cn/RAILWISE-CLI
+gh secret set APPLE_SIGNING_IDENTITY --repo railwise-cn/RAILWISE-CLI
+gh secret set SIGNPATH_API_TOKEN --repo railwise-cn/RAILWISE-CLI
+gh secret set SIGNPATH_ORG_ID --repo railwise-cn/RAILWISE-CLI
+```
+
+`APPLE_CERTIFICATE` 必须是 base64 编码后的 `.p12` 内容：
+
+```bash
+base64 -i certificate.p12 -o certificate.p12.base64
+```
+
+配置后检查 secret 名称：
+
+```bash
+gh secret list --repo railwise-cn/RAILWISE-CLI
+```
+
+## 发布前本地检查
+
+在触发 GitHub Actions 前执行：
+
+```bash
+bun run script/verify-desktop-release.ts
+bun run desktop:verify:ga
+```
+
+完整 live gate：
+
+```bash
+bun run desktop:verify:ga -- --full
+```
+
+## 触发发布
+
+手动触发 `Desktop Release` workflow：
+
+```bash
+gh workflow run "Desktop Release" --repo railwise-cn/RAILWISE-CLI --ref main -f version=1.3.0
+```
+
+或推送发布标签：
+
+```bash
+git tag desktop/v1.3.0
+git push origin desktop/v1.3.0
+```
+
+推荐 GA 首次发版使用手动触发，确认 draft Release 产物完整后再决定是否保留或补标签。
+
+## 验收 Release
+
+workflow 成功后检查 draft Release：
+
+```bash
+gh release view desktop/v1.3.0 --repo railwise-cn/RAILWISE-CLI --json isDraft,assets,tagName,url
+```
+
+必须覆盖以下产物类型：
+
+- Windows signed installer: `.exe`
+- macOS installer: `.dmg`
+- Linux packages: `.AppImage`, `.deb`, `.rpm`
+
+## 更新服务器
+
+Release 产物确认后，将安装包和 Tauri updater 签名写入更新服务器 manifest。更新接口必须兼容：
+
+```text
+GET /desktop/{{target}}/{{current_version}}
+```
+
+灰度节奏见 `docs/admin/04-update-server.md`。
+
+## 回滚
+
+如果发布后出现 P0/P1：
+
+1. 暂停更新服务器返回新版本。
+2. 将 manifest 回退到上一个稳定版本。
+3. 保留 GitHub draft/release 产物用于排查，不直接删除。
+4. 修复后重新走完整 `desktop:verify:ga -- --full`。

--- a/docs/dev/05-release-cadence.md
+++ b/docs/dev/05-release-cadence.md
@@ -16,6 +16,18 @@ RC2 在 P0/P1 清零后发布，验证期 3 天。回归范围必须包含崩溃
 
 GA 发布版本为 `desktop/v1.3.0` 起步。更新服务器按 10%、30%、100% 灰度推进，每阶段间隔 24 小时。GitHub Release 需要附 changelog，内网分发由管理员通过私有更新服务器推送。
 
+## GitHub Actions 发布
+
+桌面正式包由 `Desktop Release` workflow 生成。管理员可以通过 `workflow_dispatch` 手动输入版本号，也可以推送 `desktop/v*` 标签触发。
+
+首次 GA 推荐使用手动触发：
+
+```bash
+gh workflow run "Desktop Release" --repo railwise-cn/RAILWISE-CLI --ref main -f version=1.3.0
+```
+
+触发前必须完成发布 secrets 配置。完整清单和配置命令见 `docs/admin/06-desktop-release-runbook.md`。
+
 ## 发布前检查
 
 ```bash
@@ -27,7 +39,7 @@ cd packages/desktop/src-tauri && cargo check
 cd packages/desktop && bun run test:e2e
 ```
 
-发布前还必须执行品牌残留扫描，确保当前 UI、桌面壳和交付文档不再出现旧工作台命名。
+发布前还必须执行品牌残留扫描，确保当前 UI、桌面壳和交付文档不再出现历史命名残留。
 
 仓库根目录的总体验收入口会串联品牌残留扫描、M6 发布配置、M7 内测验收、更新分发服务验收和各 package typecheck：
 
@@ -46,3 +58,13 @@ bun run desktop:verify:ga
 ```bash
 bun run desktop:verify:ga -- --full
 ```
+
+## 发布阻断项
+
+以下任一项失败时不得进入 GA：
+
+- `Desktop Release` workflow 在 `Validate release secrets` 步骤提示缺少 secret。
+- macOS codesign 或 notarization 失败。
+- Windows SignPath 签名失败。
+- draft Release 缺少 Windows、macOS 或 Linux 任一平台产物。
+- 更新服务器 manifest 未包含新版本签名和下载地址。


### PR DESCRIPTION
## Summary
- Add an administrator runbook for Desktop Release secrets, local preflight, workflow triggering, release asset checks, update server handoff, and rollback.
- Link the runbook from administrator deployment docs and developer release cadence docs.
- Clarify GA blockers and keep the release cadence wording aligned with current brand-residue checks.

## Verification
- `bunx prettier --check docs/admin/06-desktop-release-runbook.md docs/dev/05-release-cadence.md docs/admin/01-deploy.md`
- `bun run script/verify-desktop-release.ts`
- `bun run desktop:verify:ga`
- `git diff --check`
- Pre-push hook: `bun turbo typecheck`
