### PR TITLE
ci: rotate desktop updater signing key

### DIFF
--- a/packages/desktop/src-tauri/tauri.prod.conf.json
+++ b/packages/desktop/src-tauri/tauri.prod.conf.json
@@ -58,7 +58,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEYwMDM5Nzg5OUMzOUExMDQKUldRRW9UbWNpWmNEOENYT01CV0lhOXR1UFhpaXJsK1Z3aU9lZnNtNzE0TDROWVMwVW9XQnFOelkK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEIwMTYxMUNEQTM0NkMyOTcKUldTWHdrYWp6UkVXc08rYStqOUJvQVdlV2ZwenlML2FzVlorbm1HdldQa2ZCSUc4MFFlWG9EOWQK",
       "endpoints": ["https://updates.railwise.cn/desktop/{{target}}/{{current_version}}"],
       "windows": {
         "installMode": "passive"


### PR DESCRIPTION
## Summary
- rotate the Desktop updater public key in production Tauri config
- configure matching Tauri updater private key/password in GitHub Actions secrets
- configure generated macOS CI keychain password secret

## Verification
- bun run script/verify-desktop-release.ts
- bun run desktop:verify:ga
- local Tauri signer smoke test using the generated private key
- bun run desktop:release-secrets confirms shared secrets are configured and flags the remaining Apple/SignPath credentials