### PR TITLE
test(core): lock workflow delivery contract

### DIFF
--- a/docs/dev/10-delivery-package-boundary-map.md
+++ b/docs/dev/10-delivery-package-boundary-map.md
@@ -86,6 +86,26 @@ Compatibility rules:
 - Increment `delivery.version` when package layout or required field semantics change.
 - Increment root `version` when manifest-level fields or compatibility rules change.
 
+### 2.2 SDK update rule
+
+Regenerate the JavaScript SDK when a delivery change touches an HTTP request or response schema:
+
+- `WorkflowDeliveryArchive`
+- `WorkflowSession`
+- `WorkflowAcceptance`
+- `/agent-studio/workflow/session/:sessionId`
+- `/agent-studio/workflow/acceptance`
+- `/agent-studio/workflow/delivery/archive`
+
+Use:
+
+```bash
+./packages/sdk/js/script/build.ts
+cd packages/sdk/js && bun run typecheck
+```
+
+Do not regenerate the SDK for a manifest-only change that is never returned through HTTP. For those changes, update the manifest fixture coverage in `packages/railwise/test/server/agent-studio.test.ts` and document the compatibility decision in this file.
+
 ---
 
 ## 3. Desktop / App UI 边界

--- a/packages/railwise/src/server/routes/agent-studio.ts
+++ b/packages/railwise/src/server/routes/agent-studio.ts
@@ -147,7 +147,7 @@ const WorkflowDeliveryArchiveSchema = z
     sessionId: z.string(),
     workflowId: z.string(),
     workflowName: z.string(),
-    version: z.number().int(),
+    version: z.literal(WORKFLOW_DELIVERY_PACKAGE_VERSION),
     generatedAt: z.string(),
     directoryPath: z.string().optional(),
     absoluteDirectoryPath: z.string().optional(),
@@ -163,7 +163,7 @@ const WorkflowDeliveryArchiveSchema = z
 const WorkflowDeliveryManifestSchema = z
   .object({
     kind: z.literal(WORKFLOW_DELIVERY_MANIFEST_KIND),
-    version: z.number().int(),
+    version: z.literal(WORKFLOW_DELIVERY_MANIFEST_VERSION),
     delivery: WorkflowDeliveryArchiveSchema,
     acceptance: WorkflowAcceptanceSchema,
     references: WorkflowDeliveryReferenceSchema.array(),

--- a/packages/railwise/test/server/agent-studio.test.ts
+++ b/packages/railwise/test/server/agent-studio.test.ts
@@ -426,10 +426,10 @@ describe("server.routes.agent-studio", () => {
               fileCount: number
               markdownPath: string
               manifestPath: string
-              files: { kind: string; path: string; copied: boolean }[]
+              files: { kind: string; label: string; path: string; copied: boolean; sourcePath?: string }[]
             }
             acceptance: { workflowId: string; ok: boolean }
-            references: { path: string }[]
+            references: { label: string; path: string }[]
           }
           const metadataResponse = await AgentStudioRoutes().request(
             `http://railwise.test/workflow/session/${session.id}`,
@@ -445,11 +445,21 @@ describe("server.routes.agent-studio", () => {
           expect(result.manifestPath).toContain("/manifest.json")
           expect(result.fileCount).toBe(4)
           expect(result.files.filter((file) => file.copied)).toHaveLength(4)
+          expect(result.files.map((file) => path.basename(file.path))).toEqual([
+            "summary.md",
+            "artifact-01.md",
+            "artifact-02.json",
+            "manifest.json",
+          ])
+          expect(result.files.map((file) => file.kind)).toEqual(["summary", "artifact", "artifact", "manifest"])
           expect(result.files.find((file) => file.sourcePath === md)?.path).toContain("artifact-01.md")
           expect(result.files.find((file) => file.sourcePath === json)?.path).toContain("artifact-02.json")
           expect(markdown).toContain("# CPIII 规范查询与复测预案 交付摘要")
           expect(markdown).toContain("- 交付包版本: 1")
+          expect(markdown).toContain("- Manifest: ")
           expect(markdown).toContain("## 交付包文件")
+          expect(markdown).toContain("| 交付摘要 Markdown | summary |")
+          expect(markdown).toContain("| 交付清单 JSON | manifest |")
           expect(markdown).toContain(md)
           expect(markdown).toContain(json)
           expect(markdown).toContain("## 验收检查")
@@ -461,13 +471,46 @@ describe("server.routes.agent-studio", () => {
           })
           expect(manifest.kind).toBe("railwise.workflow.delivery")
           expect(manifest.version).toBe(1)
+          expect(["kind", "version", "delivery", "acceptance", "references"].every((key) => key in manifest)).toBe(true)
+          expect(
+            [
+              "sessionId",
+              "workflowId",
+              "workflowName",
+              "version",
+              "generatedAt",
+              "directoryPath",
+              "markdownPath",
+              "manifestPath",
+              "fileCount",
+              "files",
+            ].every((key) => key in manifest.delivery),
+          ).toBe(true)
           expect(manifest.delivery.version).toBe(1)
           expect(manifest.delivery.fileCount).toBe(4)
           expect(manifest.delivery.markdownPath).toBe(result.markdownPath)
           expect(manifest.delivery.manifestPath).toBe(result.manifestPath)
-          expect(manifest.delivery.files.map((file) => file.kind)).toEqual(["summary", "artifact", "artifact", "manifest"])
+          expect(manifest.delivery.files.map((file) => file.kind)).toEqual([
+            "summary",
+            "artifact",
+            "artifact",
+            "manifest",
+          ])
+          expect(manifest.delivery.files.map((file) => path.basename(file.path))).toEqual([
+            "summary.md",
+            "artifact-01.md",
+            "artifact-02.json",
+            "manifest.json",
+          ])
+          expect(manifest.delivery.files.map((file) => file.sourcePath).filter(Boolean)).toEqual([md, json])
           expect(manifest.acceptance.workflowId).toBe("cpiii-resurvey-wiki")
           expect(manifest.acceptance.ok).toBe(true)
+          expect(
+            ["workflowId", "sessionId", "ok", "generatedAt", "messageCount", "checks"].every(
+              (key) => key in manifest.acceptance,
+            ),
+          ).toBe(true)
+          expect(manifest.references.map((reference) => reference.label)).toEqual(["Markdown", "JSON"])
           expect(manifest.references.map((reference) => reference.path)).toContain(md)
           expect(metadata.delivery.markdownPath).toBe(result.markdownPath)
           expect(metadata.delivery.directoryPath).toBe(result.directoryPath)

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2436,7 +2436,7 @@ export type WorkflowDeliveryArchive = {
   sessionId: string
   workflowId: string
   workflowName: string
-  version: number
+  version: 1
   generatedAt: string
   directoryPath?: string
   absoluteDirectoryPath?: string


### PR DESCRIPTION
## Summary

- Lock workflow delivery archive versions as literal contract values.
- Add Core contract coverage for summary.md, manifest.json, artifact file ordering, required manifest fields, and copied artifact names.
- Regenerate the JavaScript SDK so WorkflowDeliveryArchive.version is typed as 1.
- Document when delivery changes require SDK regeneration versus manifest-only fixture updates.

### Product line

- [x] Core
- [ ] CLI
- [ ] Desktop
- [ ] App shell
- [ ] Docs
- [ ] CI/release infrastructure

## Issue

Closes #13.

## Validation

- cd packages/railwise && bun run typecheck
- cd packages/railwise && bun test --timeout 30000 test/server/agent-studio.test.ts
- cd packages/railwise && bun test --timeout 30000 test/agent/railwise-v2.test.ts test/agent/agent.test.ts
- cd packages/railwise && bun test --timeout 30000 test/tool/wiki.test.ts test/tool/adjustment.test.ts
- cd packages/sdk/js && bun run typecheck
- git diff --check
- git push pre-push hook: bun turbo typecheck
