### PR TITLE
fix(ci): guard unconfigured release workflows

### DIFF
--- a/.github/actions/setup-git-committer/action.yml
+++ b/.github/actions/setup-git-committer/action.yml
@@ -3,31 +3,37 @@ description: "Create app token and configure git user"
 inputs:
   railwise-app-id:
     description: "RAILWISE GitHub App ID"
-    required: true
+    required: false
   railwise-app-secret:
     description: "RAILWISE GitHub App private key"
-    required: true
+    required: false
 outputs:
   token:
     description: "GitHub App token"
-    value: ${{ steps.apptoken.outputs.token }}
+    value: ${{ steps.apptoken.outputs.token || github.token }}
   app-slug:
     description: "GitHub App slug"
-    value: ${{ steps.apptoken.outputs.app-slug }}
+    value: ${{ steps.apptoken.outputs.app-slug || 'github-actions' }}
 runs:
   using: "composite"
   steps:
     - name: Create app token
       id: apptoken
+      if: ${{ inputs.railwise-app-id != '' && inputs.railwise-app-secret != '' }}
       uses: actions/create-github-app-token@v2
       with:
         app-id: ${{ inputs.railwise-app-id }}
         private-key: ${{ inputs.railwise-app-secret }}
         owner: ${{ github.repository_owner }}
 
+    - name: Use GitHub token fallback
+      if: ${{ inputs.railwise-app-id == '' || inputs.railwise-app-secret == '' }}
+      run: echo "RAILWISE GitHub App credentials are not configured; using GITHUB_TOKEN."
+      shell: bash
+
     - name: Configure git user
       run: |
-        slug="${{ steps.apptoken.outputs.app-slug }}"
+        slug="${{ steps.apptoken.outputs.app-slug || 'github-actions' }}"
         git config --global user.name "${slug}[bot]"
         git config --global user.email "${slug}[bot]@users.noreply.github.com"
       shell: bash
@@ -39,5 +45,5 @@ runs:
 
     - name: Configure git remote
       run: |
-        git remote set-url origin https://x-access-token:${{ steps.apptoken.outputs.token }}@github.com/${{ github.repository }}
+        git remote set-url origin https://x-access-token:${{ steps.apptoken.outputs.token || github.token }}@github.com/${{ github.repository }}
       shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,11 +13,33 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - name: Check deploy secrets
+        id: secrets
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          PLANETSCALE_SERVICE_TOKEN_NAME: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_NAME }}
+          PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
+          STRIPE_SECRET_KEY_DEV: ${{ secrets.STRIPE_SECRET_KEY_DEV }}
+          STRIPE_SECRET_KEY_PROD: ${{ secrets.STRIPE_SECRET_KEY_PROD }}
+        run: |
+          stripe_key="$STRIPE_SECRET_KEY_DEV"
+          if [ "${{ github.ref_name }}" = "production" ]; then
+            stripe_key="$STRIPE_SECRET_KEY_PROD"
+          fi
+          if [ -z "$CLOUDFLARE_API_TOKEN" ] || [ -z "$PLANETSCALE_SERVICE_TOKEN_NAME" ] || [ -z "$PLANETSCALE_SERVICE_TOKEN" ] || [ -z "$stripe_key" ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "Deploy secrets are not fully configured for ${{ github.ref_name }}; skipping deploy."
+            exit 0
+          fi
+          echo "ready=true" >> "$GITHUB_OUTPUT"
 
       - uses: ./.github/actions/setup-bun
+        if: steps.secrets.outputs.ready == 'true'
 
       - uses: actions/setup-node@v4
+        if: steps.secrets.outputs.ready == 'true'
         with:
           node-version: "24"
 
@@ -28,11 +50,21 @@ jobs:
       # Removing the system language plugin forces SST to use its bundled compatible version.
       # TODO: Remove when sst supports Pulumi >3.210.0
       - name: Fix Pulumi version conflict
+        if: steps.secrets.outputs.ready == 'true'
         run: sudo rm -f /usr/local/bin/pulumi-language-nodejs
 
-      - run: bun sst deploy --stage=${{ github.ref_name }}
+      - name: Deploy
+        if: steps.secrets.outputs.ready == 'true'
+        run: |
+          if [ "${{ github.ref_name }}" = "production" ]; then
+            export STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY_PROD"
+          else
+            export STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY_DEV"
+          fi
+          bun sst deploy --stage=${{ github.ref_name }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           PLANETSCALE_SERVICE_TOKEN_NAME: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_NAME }}
           PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
-          STRIPE_SECRET_KEY: ${{ github.ref_name == 'production' && secrets.STRIPE_SECRET_KEY_PROD || secrets.STRIPE_SECRET_KEY_DEV }}
+          STRIPE_SECRET_KEY_DEV: ${{ secrets.STRIPE_SECRET_KEY_DEV }}
+          STRIPE_SECRET_KEY_PROD: ${{ secrets.STRIPE_SECRET_KEY_PROD }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -37,7 +37,7 @@ jobs:
           git add -A
           git commit -m "chore: generate" --allow-empty
           git push origin HEAD:${{ github.ref_name }} --no-verify
-          # if ! git push origin HEAD:${{ github.event.pull_request.head.ref || github.ref_name }} --no-verify; then
+          # if ! git push origin HEAD:<target-branch> --no-verify; then
           #   echo ""
           #   echo "============================================"
           #   echo "Failed to push generated code."

--- a/github/script/release
+++ b/github/script/release
@@ -13,8 +13,8 @@ done
 git fetch --force --tags
 latest_tag=$(git tag --sort=committerdate | grep -E '^github-v[0-9]+\.[0-9]+\.[0-9]+$' | tail -1)
 if [ -z "$latest_tag" ]; then
-    echo "No tags found"
-    exit 1
+    echo "No github-v* tags found; skipping release."
+    exit 0
 fi
 
 echo "Latest tag: $latest_tag"


### PR DESCRIPTION
### Issue for this PR\n\nCloses #18\n\n### Type of change\n\n- [x] Bug fix\n- [ ] New feature\n- [ ] Refactor / code improvement\n- [ ] Documentation\n\n### Product line\n\n- [ ] Core (`packages/railwise`, SDK contracts, server/API, tools, workflows)\n- [ ] CLI (`packages/railwise/src/cli`, command-line UX, scripting, CI/headless usage)\n- [ ] Desktop (`packages/desktop`, native shell, local files, installer, updater, desktop UX)\n- [ ] App shell (`packages/app`, shared SolidJS UI used by browser preview and Desktop)\n- [ ] Docs only\n- [x] CI / release infrastructure\n\n### What does this PR do?\n\nThis PR keeps dev-branch release infrastructure from reporting false failures while optional publishing credentials are not configured yet. It lets setup-git-committer fall back to GITHUB_TOKEN when the Railwise GitHub App credentials are empty, skips deploy cleanly when Cloudflare/PlanetScale/Stripe secrets are missing, avoids using the dev Stripe key as a production fallback, and lets the GitHub Action release script exit successfully when no github-v* release tag exists.\n\nIt also removes an obsolete commented expression from generate.yml so workflow linting stays clean.\n\n### How did you verify your code works?\n\n- `ruby -e "require 'yaml'; %w[.github/actions/setup-git-committer/action.yml .github/workflows/deploy.yml .github/workflows/generate.yml .github/workflows/release-github-action.yml].each { |f| YAML.load_file(f) }; puts 'yaml ok'"`\n- `bash -n github/script/release`\n- `git diff --check`\n- `/tmp/actionlint-bin/actionlint -color=false .github/workflows/deploy.yml .github/workflows/generate.yml .github/workflows/release-github-action.yml`\n- pre-push hook ran `bun turbo typecheck` successfully\n\n### Screenshots / recordings\n\nN/A, CI-only change.\n\n### Checklist\n\n- [x] I have tested my changes locally\n- [x] I have not included unrelated changes in this PR\n- [x] I have identified the affected product line and used product-specific validation