### PR TITLE
fix(ci): move actions to node 24 runtime

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache Bun dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.bun/install/cache
         key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}

--- a/.github/actions/setup-git-committer/action.yml
+++ b/.github/actions/setup-git-committer/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Create app token
       id: apptoken
       if: ${{ inputs.railwise-app-id != '' && inputs.railwise-app-secret != '' }}
-      uses: actions/create-github-app-token@v2
+      uses: actions/create-github-app-token@v3
       with:
         app-id: ${{ inputs.railwise-app-id }}
         private-key: ${{ inputs.railwise-app-secret }}

--- a/.github/publish-python-sdk.yml
+++ b/.github/publish-python-sdk.yml
@@ -16,7 +16,7 @@
 #       contents: read
 #     steps:
 #       - name: Checkout repository
-#         uses: actions/checkout@v4
+#         uses: actions/checkout@v6
 
 #       - name: Setup Bun
 #         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Close inactive PRs
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/compliance-close.yml
+++ b/.github/workflows/compliance-close.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close non-compliant issues and PRs after 2 hours
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const branch = context.payload.repository?.default_branch || 'main';

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -21,7 +21,7 @@ jobs:
       REGISTRY: ghcr.io/${{ github.repository_owner }}
       TAG: "24.04"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-bun
 

--- a/.github/workflows/daily-issues-recap.yml
+++ b/.github/workflows/daily-issues-recap.yml
@@ -14,7 +14,7 @@ jobs:
       issues: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/daily-pr-recap.yml
+++ b/.github/workflows/daily-pr-recap.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check deploy secrets
         id: secrets
@@ -38,7 +38,7 @@ jobs:
       - uses: ./.github/actions/setup-bun
         if: steps.secrets.outputs.ready == 'true'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         if: steps.secrets.outputs.ready == 'true'
         with:
           node-version: "24"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -35,7 +35,7 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             platform: darwin
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             platform: darwin
           - os: ubuntu-22.04
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -136,7 +136,7 @@ jobs:
       - name: Upload unsigned Windows installer
         if: matrix.platform == 'windows'
         id: upload_unsigned_windows
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unsigned-railwise-desktop-windows
           path: |
@@ -158,14 +158,14 @@ jobs:
 
       - name: Upload signed Windows installer
         if: matrix.platform == 'windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: railwise-desktop-${{ matrix.target }}-signed
           path: dist/signed/*.exe
           if-no-files-found: error
 
       - name: Upload bundle artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: railwise-desktop-${{ matrix.target }}
           path: |
@@ -180,7 +180,7 @@ jobs:
     needs: build
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist/desktop
           merge-multiple: true

--- a/.github/workflows/docs-locale-sync.yml
+++ b/.github/workflows/docs-locale-sync.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch full history to access commits
 

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -125,7 +125,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun

--- a/.github/workflows/nix-hashes.yml
+++ b/.github/workflows/nix-hashes.yml
@@ -68,7 +68,7 @@ jobs:
           echo "Computed hash for ${SYSTEM}: $HASH"
 
       - name: Upload hash
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: hash-${{ matrix.system }}
           path: hash.txt
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -98,7 +98,7 @@ jobs:
           git pull --rebase --autostash origin "$GITHUB_REF_NAME"
 
       - name: Download hash artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: hashes
           pattern: hash-*

--- a/.github/workflows/pr-management.yml
+++ b/.github/workflows/pr-management.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -102,7 +102,7 @@ jobs:
       issues: write
     steps:
       - name: Add Contributor Label
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const isPR = !!context.payload.pull_request;

--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check PR standards
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -163,7 +163,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check PR template compliance
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/publish-github-action.yml
+++ b/.github/workflows/publish-github-action.yml
@@ -16,7 +16,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -15,7 +15,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
             target: windows-x64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -61,7 +61,7 @@ jobs:
           RAILWISE_BUMP: ${{ inputs.bump || '' }}
           RAILWISE_CHANNEL: ${{ (inputs.bump || inputs.version) && 'latest' || github.ref_name }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: railwise-${{ matrix.target }}
           path: packages/railwise/dist
@@ -71,16 +71,16 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'railwise-cn/RAILWISE-CLI'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-bun
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: packages/railwise/dist
           merge-multiple: true

--- a/.github/workflows/railwise.yml
+++ b/.github/workflows/railwise.yml
@@ -19,7 +19,7 @@ jobs:
       issues: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-bun
 

--- a/.github/workflows/release-github-action.yml
+++ b/.github/workflows/release-github-action.yml
@@ -16,7 +16,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -25,7 +25,7 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/sign-cli.yml
+++ b/.github/workflows/sign-cli.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'railwise-cn/RAILWISE-CLI'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-tags: true
 
@@ -27,7 +27,7 @@ jobs:
 
       - name: Upload unsigned Windows CLI
         id: upload_unsigned_windows_cli
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unsigned-railwise-windows-cli
           path: packages/railwise/dist/railwise-windows-x64/bin/railwise.exe
@@ -47,7 +47,7 @@ jobs:
           output-artifact-directory: signed-railwise-cli
 
       - name: Upload signed Windows CLI
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: signed-railwise-windows-cli
           path: signed-railwise-cli/*.exe

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v10.2.0
         with:
           days-before-stale: ${{ env.DAYS_BEFORE_STALE }}
           days-before-close: ${{ env.DAYS_BEFORE_CLOSE }}

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun

--- a/.github/workflows/sync-zed-extension.yml
+++ b/.github/workflows/sync-zed-extension.yml
@@ -10,7 +10,7 @@ jobs:
     name: Release Zed Extension
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -51,7 +51,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload Playwright artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-${{ matrix.settings.name }}-${{ github.run_attempt }}
           if-no-files-found: ignore

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun

--- a/.github/workflows/vouch-check-issue.yml
+++ b/.github/workflows/vouch-check-issue.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if issue author is denounced
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const author = context.payload.issue.user.login;

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if PR author is denounced
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const author = context.payload.pull_request.user.login;

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -17,7 +17,7 @@ jobs:
   manage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0


### PR DESCRIPTION
### Issue for this PR\n\nCloses #20\n\n### Type of change\n\n- [x] Bug fix\n- [ ] New feature\n- [ ] Refactor / code improvement\n- [ ] Documentation\n\n### Product line\n\n- [ ] Core (`packages/railwise`, SDK contracts, server/API, tools, workflows)\n- [ ] CLI (`packages/railwise/src/cli`, command-line UX, scripting, CI/headless usage)\n- [ ] Desktop (`packages/desktop`, native shell, local files, installer, updater, desktop UX)\n- [ ] App shell (`packages/app`, shared SolidJS UI used by browser preview and Desktop)\n- [ ] Docs only\n- [x] CI / release infrastructure\n\n### What does this PR do?\n\nThis PR removes GitHub Actions Node.js 20 runtime deprecation risk by upgrading official action pins to current Node 24-ready majors. It updates checkout, cache, setup-node, artifact, github-script, stale, and GitHub App token actions across CI and release workflows.\n\nIt also updates the desktop release Intel macOS runner from the retired `macos-13` label to `macos-15-intel`, matching the current hosted runner labels.\n\nReference versions checked from official GitHub releases:\n- https://github.com/actions/checkout/releases/tag/v6.0.2\n- https://github.com/actions/cache/releases/tag/v5.0.5\n- https://github.com/actions/setup-node/releases/tag/v6.4.0\n- https://github.com/actions/upload-artifact/releases/tag/v7.0.1\n- https://github.com/actions/download-artifact/releases/tag/v8.0.1\n- https://github.com/actions/github-script/releases/tag/v9.0.0\n\n### How did you verify your code works?\n\n- `ruby -e "require 'yaml'; Dir['.github/**/*.yml', '.github/**/*.yaml'].each { |f| YAML.load_file(f) }; puts 'yaml ok'"`\n- `git diff --check origin/dev..HEAD`\n- `/tmp/actionlint-bin/actionlint -color=false .github/workflows/*.yml`\n- `rg -n "actions/(checkout@v[34]|cache@v4|setup-node@v4|upload-artifact@v4|download-artifact@v4|github-script@v[78]|create-github-app-token@v2|stale@v10($|[^.0-9]))|macos-13" .github -g '*.yml' -g '*.yaml'` returned no matches\n- pre-push hook ran `bun turbo typecheck` successfully\n\n### Screenshots / recordings\n\nN/A, CI-only change.\n\n### Checklist\n\n- [x] I have tested my changes locally\n- [x] I have not included unrelated changes in this PR\n- [x] I have identified the affected product line and used product-specific validation