### PR TITLE
ci(desktop): allow platform-scoped release runs

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -10,6 +10,16 @@ on:
         description: "版本号（如 1.3.0）"
         required: true
         type: string
+      platform:
+        description: "发布平台"
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - macos
+          - windows
+          - linux
 
 permissions:
   contents: write
@@ -22,25 +32,47 @@ env:
   TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
 jobs:
+  plan:
+    name: Select release targets
+    runs-on: ubuntu-22.04
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      platform: ${{ steps.matrix.outputs.platform }}
+    steps:
+      - name: Build target matrix
+        id: matrix
+        shell: bash
+        env:
+          PLATFORM: ${{ github.event_name == 'workflow_dispatch' && inputs.platform || 'all' }}
+        run: |
+          case "$PLATFORM" in
+            all)
+              matrix='{"include":[{"os":"windows-2022","target":"x86_64-pc-windows-msvc","platform":"windows"},{"os":"macos-14","target":"aarch64-apple-darwin","platform":"darwin"},{"os":"macos-15-intel","target":"x86_64-apple-darwin","platform":"darwin"},{"os":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","platform":"linux"}]}'
+              ;;
+            macos)
+              matrix='{"include":[{"os":"macos-14","target":"aarch64-apple-darwin","platform":"darwin"},{"os":"macos-15-intel","target":"x86_64-apple-darwin","platform":"darwin"}]}'
+              ;;
+            windows)
+              matrix='{"include":[{"os":"windows-2022","target":"x86_64-pc-windows-msvc","platform":"windows"}]}'
+              ;;
+            linux)
+              matrix='{"include":[{"os":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","platform":"linux"}]}'
+              ;;
+            *)
+              echo "Unsupported platform: $PLATFORM" >&2
+              exit 1
+              ;;
+          esac
+          echo "platform=$PLATFORM" >> "$GITHUB_OUTPUT"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
   build:
     name: ${{ matrix.platform }} / ${{ matrix.target }}
+    needs: plan
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - os: windows-2022
-            target: x86_64-pc-windows-msvc
-            platform: windows
-          - os: macos-14
-            target: aarch64-apple-darwin
-            platform: darwin
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-            platform: darwin
-          - os: ubuntu-22.04
-            target: x86_64-unknown-linux-gnu
-            platform: linux
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
 
     steps:
       - name: Checkout

--- a/docs/admin/06-desktop-release-runbook.md
+++ b/docs/admin/06-desktop-release-runbook.md
@@ -105,6 +105,16 @@ bun run desktop:verify:ga -- --full
 gh workflow run "Desktop Release" --repo railwise-cn/RAILWISE-CLI --ref dev -f version=1.3.0
 ```
 
+发布流程也支持只跑单个平台，适合在某个平台签名密钥刚配置完成时做预检：
+
+```bash
+gh workflow run "Desktop Release" --repo railwise-cn/RAILWISE-CLI --ref dev -f version=1.3.0-macos-preflight -f platform=macos
+gh workflow run "Desktop Release" --repo railwise-cn/RAILWISE-CLI --ref dev -f version=1.3.0-windows-preflight -f platform=windows
+gh workflow run "Desktop Release" --repo railwise-cn/RAILWISE-CLI --ref dev -f version=1.3.0-linux-preflight -f platform=linux
+```
+
+`platform=all` 是默认值。推送 `desktop/v*` 标签时始终构建 Windows、macOS Apple Silicon、macOS Intel 和 Linux 全平台矩阵。
+
 或推送发布标签：
 
 ```bash


### PR DESCRIPTION
## Summary

- add a Desktop Release workflow_dispatch platform input for all/macos/windows/linux
- generate the build matrix from the selected platform while keeping tag pushes on the full matrix
- document macOS, Windows, and Linux platform-scoped preflight commands

## Product line

Desktop

## Validation

- ruby YAML parse for .github/workflows/desktop-release.yml
- actionlint for .github/workflows/desktop-release.yml
- local matrix JSON validation for all/macos/windows/linux
- git diff --check
- pre-push bun turbo typecheck

Part of #15.