### PR TITLE
ci(desktop): run release build scripts through bun

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -140,7 +140,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build sidecar
-        run: bun --cwd packages/desktop run predev -- --target ${{ matrix.target }}
+        run: bun run --cwd packages/desktop predev -- --target ${{ matrix.target }}
 
       - name: macOS Import Certificate
         if: matrix.platform == 'darwin'
@@ -163,7 +163,7 @@ jobs:
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-        run: bun --cwd packages/desktop run tauri -- build --target ${{ matrix.target }} --config tauri.prod.conf.json
+        run: bun run --cwd packages/desktop tauri -- build --target ${{ matrix.target }} --config tauri.prod.conf.json
 
       - name: Upload unsigned Windows installer
         if: matrix.platform == 'windows'

--- a/scripts/verify-desktop-release.ts
+++ b/scripts/verify-desktop-release.ts
@@ -134,8 +134,8 @@ check(
 check(
   "release build command",
   contains(workflow, [
-    "bun --cwd packages/desktop run predev -- --target",
-    "bun --cwd packages/desktop run tauri -- build",
+    "bun run --cwd packages/desktop predev -- --target",
+    "bun run --cwd packages/desktop tauri -- build",
     "--config tauri.prod.conf.json",
   ]),
   "production Tauri config is used and CLI args are passed through Bun",


### PR DESCRIPTION
## Summary

- fix Desktop Release Bun script invocation so predev and tauri build actually execute
- update the desktop release verifier to lock the corrected Bun command form

## Product line

Desktop

## Root cause

The macOS-only release preflight reached secret validation and certificate import, but `bun --cwd packages/desktop run ...` printed Bun help and exited 0, so no Tauri bundle was produced. The workflow then failed at artifact upload.

## Validation

- ruby YAML parse for .github/workflows/desktop-release.yml
- actionlint for .github/workflows/desktop-release.yml
- `bun run --cwd packages/desktop tauri -- --help`
- `bun run script/verify-desktop-release.ts`
- git diff --check
- pre-push bun turbo typecheck

Part of #15.