### PR TITLE
ci(desktop): fix release config path

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -163,7 +163,7 @@ jobs:
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-        run: bun run --cwd packages/desktop tauri -- build --target ${{ matrix.target }} --config tauri.prod.conf.json
+        run: bun run --cwd packages/desktop tauri -- build --target ${{ matrix.target }} --config src-tauri/tauri.prod.conf.json
 
       - name: Upload unsigned Windows installer
         if: matrix.platform == 'windows'

--- a/scripts/verify-desktop-release.ts
+++ b/scripts/verify-desktop-release.ts
@@ -136,7 +136,7 @@ check(
   contains(workflow, [
     "bun run --cwd packages/desktop predev -- --target",
     "bun run --cwd packages/desktop tauri -- build",
-    "--config tauri.prod.conf.json",
+    "--config src-tauri/tauri.prod.conf.json",
   ]),
   "production Tauri config is used and CLI args are passed through Bun",
 )


### PR DESCRIPTION
## Summary
- point the desktop release workflow at the production Tauri config under src-tauri
- update the release readiness verifier to enforce the same path

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/desktop-release.yml"); puts "yaml ok"'
- GOPROXY=https://goproxy.cn,direct go run github.com/rhysd/actionlint/cmd/actionlint@latest -color .github/workflows/desktop-release.yml
- bun run script/verify-desktop-release.ts
- git diff --check
- bun turbo typecheck