### PR TITLE
ci(desktop): add macOS preflight controls

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -20,6 +20,11 @@ on:
           - macos
           - windows
           - linux
+      macos_skip_stapling:
+        description: "macOS 预检时跳过等待 notarization stapling，正式 GA 保持 false"
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -151,19 +156,30 @@ jobs:
         run: |
           echo "$APPLE_CERTIFICATE" | base64 --decode > cert.p12
           security create-keychain -p "$APPLE_KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
           security default-keychain -s build.keychain
+          security list-keychains -d user -s build.keychain
           security unlock-keychain -p "$APPLE_KEYCHAIN_PASSWORD" build.keychain
           security import cert.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$APPLE_KEYCHAIN_PASSWORD" build.keychain
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$APPLE_KEYCHAIN_PASSWORD" build.keychain
+          security find-identity -v -p codesigning build.keychain
+          rm -f cert.p12
 
       - name: Build Tauri App
+        shell: bash
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-        run: bun run --cwd packages/desktop tauri -- build --target ${{ matrix.target }} --config src-tauri/tauri.prod.conf.json
+          MACOS_SKIP_STAPLING: ${{ github.event_name == 'workflow_dispatch' && inputs.macos_skip_stapling || false }}
+        run: |
+          args=(build --ci -vv --target "${{ matrix.target }}" --config src-tauri/tauri.prod.conf.json)
+          if [ "${{ matrix.platform }}" = "darwin" ] && [ "$MACOS_SKIP_STAPLING" = "true" ]; then
+            args+=(--skip-stapling)
+          fi
+          bun run --cwd packages/desktop tauri -- "${args[@]}"
 
       - name: Upload unsigned Windows installer
         if: matrix.platform == 'windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,10 @@ jobs:
         settings:
           - name: linux
             host: ubuntu-latest
-            playwright: bunx playwright install --with-deps
+            playwright: bunx playwright install --with-deps chromium
           - name: windows
             host: windows-latest
-            playwright: bunx playwright install
+            playwright: bunx playwright install chromium
     runs-on: ${{ matrix.settings.host }}
     env:
       PLAYWRIGHT_BROWSERS_PATH: 0
@@ -61,6 +61,7 @@ jobs:
       - name: Install Playwright browsers
         working-directory: packages/app
         run: ${{ matrix.settings.playwright }}
+        timeout-minutes: 15
 
       - name: Run app e2e tests
         run: bun --cwd packages/app test:e2e:local

--- a/docs/admin/06-desktop-release-runbook.md
+++ b/docs/admin/06-desktop-release-runbook.md
@@ -115,6 +115,14 @@ gh workflow run "Desktop Release" --repo railwise-cn/RAILWISE-CLI --ref dev -f v
 
 `platform=all` 是默认值。推送 `desktop/v*` 标签时始终构建 Windows、macOS Apple Silicon、macOS Intel 和 Linux 全平台矩阵。
 
+首次 macOS notarization 可能需要数小时。只做 macOS 签名链路预检时，可以显式跳过等待 stapling：
+
+```bash
+gh workflow run "Desktop Release" --repo railwise-cn/RAILWISE-CLI --ref dev -f version=1.3.0-macos-preflight -f platform=macos -f macos_skip_stapling=true
+```
+
+`macos_skip_stapling=true` 只用于手动预检。GA 候选和正式发布必须保持默认 `false`，确保 `.app` 和 `.dmg` 等待 notarization 并完成 stapling。
+
 或推送发布标签：
 
 ```bash

--- a/scripts/verify-desktop-release.ts
+++ b/scripts/verify-desktop-release.ts
@@ -135,10 +135,16 @@ check(
   "release build command",
   contains(workflow, [
     "bun run --cwd packages/desktop predev -- --target",
-    "bun run --cwd packages/desktop tauri -- build",
+    "bun run --cwd packages/desktop tauri --",
+    "args=(build --ci -vv --target",
     "--config src-tauri/tauri.prod.conf.json",
   ]),
   "production Tauri config is used and CLI args are passed through Bun",
+)
+check(
+  "macOS preflight controls",
+  contains(workflow, ["macos_skip_stapling", "--skip-stapling", "apple-tool:,apple:,codesign:", "security find-identity"]),
+  "manual macOS preflight can skip stapling and validates codesigning identity",
 )
 check(
   "release secret preflight",


### PR DESCRIPTION
## Summary
- add a manual `macos_skip_stapling` Desktop Release input for faster macOS preflight runs
- run Tauri release builds with `--ci -vv` for better diagnostics
- harden macOS keychain setup and verify the imported codesigning identity
- document when to use skip-stapling and extend the desktop release verifier

## Verification
- `bun run script/verify-desktop-release.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/desktop-release.yml"); puts "yaml ok"'`\n- `GOPROXY=https://goproxy.cn,direct go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/desktop-release.yml`\n- `git diff --check`\n- pre-push `bun turbo typecheck`