### PR TITLE
ci(desktop): add notarization-free macos preflight

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -25,6 +25,11 @@ on:
         required: true
         default: false
         type: boolean
+      macos_skip_notarization:
+        description: "macOS 预检时跳过 Apple notarization 提交，正式 GA 保持 false"
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -112,15 +117,21 @@ jobs:
           SIGNPATH_ORG_ID: ${{ secrets.SIGNPATH_ORG_ID }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          MACOS_SKIP_NOTARIZATION: ${{ github.event_name == 'workflow_dispatch' && inputs.macos_skip_notarization || false }}
         run: |
           missing=()
           for secret in TAURI_SIGNING_PRIVATE_KEY TAURI_SIGNING_PRIVATE_KEY_PASSWORD; do
             if [ -z "${!secret}" ]; then missing+=("$secret"); fi
           done
           if [ "${{ matrix.platform }}" = "darwin" ]; then
-            for secret in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_KEYCHAIN_PASSWORD APPLE_ID APPLE_ID_PASSWORD APPLE_TEAM_ID APPLE_SIGNING_IDENTITY; do
+            for secret in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_KEYCHAIN_PASSWORD APPLE_SIGNING_IDENTITY; do
               if [ -z "${!secret}" ]; then missing+=("$secret"); fi
             done
+            if [ "$MACOS_SKIP_NOTARIZATION" != "true" ]; then
+              for secret in APPLE_ID APPLE_ID_PASSWORD APPLE_TEAM_ID; do
+                if [ -z "${!secret}" ]; then missing+=("$secret"); fi
+              done
+            fi
           fi
           if [ "${{ matrix.platform }}" = "windows" ]; then
             for secret in SIGNPATH_API_TOKEN SIGNPATH_ORG_ID; do
@@ -168,16 +179,24 @@ jobs:
       - name: Build Tauri App
         shell: bash
         env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ID_SECRET: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD_SECRET: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID_SECRET: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           MACOS_SKIP_STAPLING: ${{ github.event_name == 'workflow_dispatch' && inputs.macos_skip_stapling || false }}
+          MACOS_SKIP_NOTARIZATION: ${{ github.event_name == 'workflow_dispatch' && inputs.macos_skip_notarization || false }}
         run: |
           args=(build --ci -vv --target "${{ matrix.target }}" --config src-tauri/tauri.prod.conf.json)
-          if [ "${{ matrix.platform }}" = "darwin" ] && [ "$MACOS_SKIP_STAPLING" = "true" ]; then
-            args+=(--skip-stapling)
+          if [ "${{ matrix.platform }}" = "darwin" ]; then
+            if [ "$MACOS_SKIP_NOTARIZATION" != "true" ]; then
+              export APPLE_ID="$APPLE_ID_SECRET"
+              export APPLE_PASSWORD="$APPLE_PASSWORD_SECRET"
+              export APPLE_ID_PASSWORD="$APPLE_PASSWORD_SECRET"
+              export APPLE_TEAM_ID="$APPLE_TEAM_ID_SECRET"
+            fi
+            if [ "$MACOS_SKIP_STAPLING" = "true" ]; then
+              args+=(--skip-stapling)
+            fi
           fi
           bun run --cwd packages/desktop tauri -- "${args[@]}"
 

--- a/docs/admin/06-desktop-release-runbook.md
+++ b/docs/admin/06-desktop-release-runbook.md
@@ -23,16 +23,21 @@ TAURI_SIGNING_PRIVATE_KEY
 TAURI_SIGNING_PRIVATE_KEY_PASSWORD
 ```
 
-macOS 必需：
+macOS 代码签名必需：
 
 ```text
 APPLE_CERTIFICATE
 APPLE_CERTIFICATE_PASSWORD
 APPLE_KEYCHAIN_PASSWORD
+APPLE_SIGNING_IDENTITY
+```
+
+macOS notarization 必需：
+
+```text
 APPLE_ID
 APPLE_ID_PASSWORD
 APPLE_TEAM_ID
-APPLE_SIGNING_IDENTITY
 ```
 
 Windows 必需：
@@ -43,6 +48,8 @@ SIGNPATH_ORG_ID
 ```
 
 当前 workflow 会在构建前执行 secret preflight。缺失任意必需项时，job 会在 `Validate release secrets` 步骤失败，并列出缺失名称。
+
+手动 macOS build-only 预检可以设置 `macos_skip_notarization=true`，此时 workflow 仍会要求 Developer ID 代码签名证书，但不会要求 `APPLE_ID`、`APPLE_ID_PASSWORD`、`APPLE_TEAM_ID`，也不会向 Apple 提交 notarization。GA 候选和正式发布必须保持默认 `false`。
 
 ## 配置方式
 
@@ -121,7 +128,15 @@ gh workflow run "Desktop Release" --repo railwise-cn/RAILWISE-CLI --ref dev -f v
 gh workflow run "Desktop Release" --repo railwise-cn/RAILWISE-CLI --ref dev -f version=1.3.0-macos-preflight -f platform=macos -f macos_skip_stapling=true
 ```
 
-`macos_skip_stapling=true` 只用于手动预检。GA 候选和正式发布必须保持默认 `false`，确保 `.app` 和 `.dmg` 等待 notarization 并完成 stapling。
+`macos_skip_stapling=true` 只跳过等待和 stapling，不跳过 Apple notarization 提交；因此它仍然需要有效的 `APPLE_ID_PASSWORD` app-specific password。
+
+如果 Apple notarization 凭据还未准备好，但需要先验证 macOS 构建与 Developer ID codesign，可以运行 build-only 预检：
+
+```bash
+gh workflow run "Desktop Release" --repo railwise-cn/RAILWISE-CLI --ref dev -f version=1.3.0-macos-build-preflight -f platform=macos -f macos_skip_notarization=true -f macos_skip_stapling=true
+```
+
+`macos_skip_notarization=true` 只适合阻塞排查和签名链路预检。它生成的是 signed but not notarized 的 macOS 产物，不能作为 GA 分发包。GA 候选和正式发布必须保持 `macos_skip_notarization=false` 且 `macos_skip_stapling=false`，确保 `.app` 和 `.dmg` 完成 notarization 与 stapling。
 
 或推送发布标签：
 

--- a/scripts/verify-desktop-release.ts
+++ b/scripts/verify-desktop-release.ts
@@ -66,6 +66,7 @@ const configPath = "packages/desktop/src-tauri/tauri.prod.conf.json"
 const workflowExists = await exists(workflowPath)
 const configExists = await exists(configPath)
 const workflow = workflowExists ? await read(workflowPath) : ""
+const runbook = await read("docs/admin/06-desktop-release-runbook.md")
 const config = configExists ? ((await Bun.file(file(configPath)).json()) as Config) : {}
 const cli = await read("packages/desktop/src-tauri/src/cli.rs")
 const lib = await read("packages/desktop/src-tauri/src/lib.rs")
@@ -150,6 +151,34 @@ check(
     "security find-identity",
   ]),
   "manual macOS preflight can skip stapling and validates codesigning identity",
+)
+check(
+  "macOS notarization-free preflight",
+  contains(workflow, [
+    "macos_skip_notarization",
+    "MACOS_SKIP_NOTARIZATION",
+    "APPLE_ID_SECRET",
+    "APPLE_PASSWORD_SECRET",
+    "APPLE_TEAM_ID_SECRET",
+    "export APPLE_ID",
+    "export APPLE_PASSWORD",
+    "export APPLE_TEAM_ID",
+  ]),
+  "manual macOS build preflight can keep codesigning enabled while withholding notarization credentials",
+)
+check(
+  "macOS notarization secret gate",
+  contains(workflow, [
+    'MACOS_SKIP_NOTARIZATION: ${{ github.event_name == \'workflow_dispatch\' && inputs.macos_skip_notarization || false }}',
+    'if [ "$MACOS_SKIP_NOTARIZATION" != "true" ]; then',
+    "APPLE_ID APPLE_ID_PASSWORD APPLE_TEAM_ID",
+  ]),
+  "Apple ID notarization secrets are required only when notarization is enabled",
+)
+check(
+  "macOS preflight docs",
+  contains(runbook, ["macos_skip_notarization=true", "macos_skip_stapling=true", "notarization", "GA"]),
+  "runbook documents signed build-only preflight versus GA notarization",
 )
 check(
   "release secret preflight",


### PR DESCRIPTION
## Summary
- Add a manual macOS `macos_skip_notarization` release input for signed build-only preflight runs.
- Keep Developer ID codesigning active while withholding Apple notarization env vars when the skip flag is enabled.
- Document the difference between skip-stapling, build-only preflight, and GA notarization requirements.

## Test Plan
- `bun run script/verify-desktop-release.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/desktop-release.yml"); puts "yaml ok"'`\n- `git diff --check`\n- `GOPROXY=https://goproxy.cn,direct go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/desktop-release.yml`