### PR TITLE
ci(desktop): pass repo to draft release step

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -255,6 +255,7 @@ jobs:
       - name: Create draft GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           VERSION: ${{ inputs.version }}
         run: |
           TAG="${GITHUB_REF_NAME}"
@@ -270,6 +271,7 @@ jobs:
             -name "*.tar.gz" -o \
             -name "*.zip" \))
           gh release create "$TAG" \
+            --repo "$GH_REPO" \
             --title "RAILWISE Desktop ${TAG#desktop/}" \
             --notes "查看 CHANGELOG.md 了解更新内容" \
             --draft \

--- a/scripts/verify-desktop-release.ts
+++ b/scripts/verify-desktop-release.ts
@@ -197,6 +197,11 @@ check(
   ]),
   "draft release uploads Windows, macOS, and Linux installers",
 )
+check(
+  "release repo context",
+  contains(workflow, ['GH_REPO: ${{ github.repository }}', "--repo \"$GH_REPO\""]),
+  "draft release creation does not depend on a checked-out .git directory",
+)
 check("production config exists", configExists, configPath)
 check(
   "production identity",


### PR DESCRIPTION
## Summary
- Pass `GH_REPO` and `--repo` to `gh release create` in the Desktop Release job.
- Add a readiness check so the release job does not depend on a checked-out `.git` directory.

## Test Plan
- `bun run script/verify-desktop-release.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/desktop-release.yml"); puts "yaml ok"'`\n- `git diff --check`\n- `GOPROXY=https://goproxy.cn,direct go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/desktop-release.yml`