### PR TITLE
ci(desktop): stage release assets before upload

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -250,7 +250,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: dist/desktop
-          merge-multiple: true
+          merge-multiple: false
 
       - name: Create draft GitHub release
         env:
@@ -262,14 +262,51 @@ jobs:
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             TAG="desktop/v${VERSION}"
           fi
-          mapfile -t files < <(find dist/desktop -type f \( \
+          rm -rf dist/release-assets
+          mkdir -p dist/release-assets
+          stage() {
+            cp "$1" "dist/release-assets/$2"
+          }
+          while IFS= read -r -d '' file; do
+            case "$file" in
+              */unsigned-railwise-desktop-windows/*)
+                continue
+                ;;
+              *aarch64-apple-darwin*/macos/*.app.tar.gz.sig)
+                stage "$file" "RAILWISE_${VERSION}_aarch64.app.tar.gz.sig"
+                ;;
+              *aarch64-apple-darwin*/macos/*.app.tar.gz)
+                stage "$file" "RAILWISE_${VERSION}_aarch64.app.tar.gz"
+                ;;
+              *x86_64-apple-darwin*/macos/*.app.tar.gz.sig)
+                stage "$file" "RAILWISE_${VERSION}_x64.app.tar.gz.sig"
+                ;;
+              *x86_64-apple-darwin*/macos/*.app.tar.gz)
+                stage "$file" "RAILWISE_${VERSION}_x64.app.tar.gz"
+                ;;
+              *)
+                name="$(basename "$file")"
+                name="${name//睿威智测 RAILWISE/RAILWISE}"
+                name="${name// /_}"
+                stage "$file" "$name"
+                ;;
+            esac
+          done < <(find dist/desktop -type f \( \
             -name "*.dmg" -o \
             -name "*.AppImage" -o \
             -name "*.deb" -o \
             -name "*.rpm" -o \
             -name "*.exe" -o \
             -name "*.tar.gz" -o \
-            -name "*.zip" \))
+            -name "*.zip" -o \
+            -name "*.sig" \) -print0)
+          mapfile -t files < <(find dist/release-assets -type f | sort)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No release assets found" >&2
+            exit 1
+          fi
+          printf 'Release assets:\n'
+          printf ' - %s\n' "${files[@]}"
           gh release create "$TAG" \
             --repo "$GH_REPO" \
             --title "RAILWISE Desktop ${TAG#desktop/}" \

--- a/scripts/verify-desktop-release.ts
+++ b/scripts/verify-desktop-release.ts
@@ -202,6 +202,17 @@ check(
   contains(workflow, ["GH_REPO: ${{ github.repository }}", '--repo "$GH_REPO"']),
   "draft release creation does not depend on a checked-out .git directory",
 )
+check(
+  "release asset staging",
+  contains(workflow, [
+    "dist/release-assets",
+    '-name "*.sig"',
+    "RAILWISE_${VERSION}_aarch64.app.tar.gz",
+    "RAILWISE_${VERSION}_x64.app.tar.gz",
+    "mapfile -t files < <(find dist/release-assets -type f | sort)",
+  ]),
+  "release assets are staged with stable ASCII names before upload",
+)
 check("production config exists", configExists, configPath)
 check(
   "production identity",


### PR DESCRIPTION
## Summary
- Preserve artifact directories when downloading release artifacts.
- Stage release assets into `dist/release-assets` with stable ASCII names before `gh release create`.
- Include macOS updater `.tar.gz` and `.sig` files with architecture-specific names, while skipping unsigned Windows installer artifacts.

## Test Plan
- `bun run script/verify-desktop-release.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/desktop-release.yml"); puts "yaml ok"'`\n- `git diff --check`\n- `GOPROXY=https://goproxy.cn,direct go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/desktop-release.yml`