### PR TITLE
feat(core): publish workflow completion events

### DIFF
--- a/packages/railwise/src/server/routes/agent-studio.ts
+++ b/packages/railwise/src/server/routes/agent-studio.ts
@@ -5,7 +5,7 @@ import path from "path"
 import { mkdir, readdir, stat } from "fs/promises"
 import z from "zod"
 import { Agent } from "../../agent/agent"
-import { AgentUpdated } from "../../agent/agent-events"
+import { AgentUpdated, WorkflowCompleted } from "../../agent/agent-events"
 import presets from "../../agent/workflow-presets.json" with { type: "json" }
 import { Bus } from "../../bus"
 import { NormWiki } from "../../norm/wiki"
@@ -1101,6 +1101,7 @@ function deliveryMarkdown(input: {
 async function acceptance(input: { workflowId: string; sessionId: string }) {
   const workflow = presets.find((item) => item.id === input.workflowId)
   if (!workflow) throw new Error(`workflow "${input.workflowId}" not found`)
+  const stored = await workflowSession(input.sessionId)
   const messages = await Session.messages({ sessionID: input.sessionId })
   const user = messages
     .filter((message) => message.info.role === "user")
@@ -1170,6 +1171,13 @@ async function acceptance(input: { workflowId: string; sessionId: string }) {
     workflowName: workflow.name,
     acceptance: result,
   })
+  const durationMs = stored ? Math.max(0, Date.parse(result.generatedAt) - Date.parse(stored.createdAt)) : 0
+  if (result.ok)
+    await Bus.publish(WorkflowCompleted, {
+      workflowId: workflow.id,
+      sessionId: input.sessionId,
+      durationMs,
+    })
   return result
 }
 

--- a/packages/railwise/test/server/agent-studio.test.ts
+++ b/packages/railwise/test/server/agent-studio.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import { mkdir } from "fs/promises"
 import path from "path"
+import { WorkflowCompleted } from "../../src/agent/agent-events"
+import { Bus } from "../../src/bus"
 import { AgentStudioRoutes } from "../../src/server/routes/agent-studio"
 import { Instance } from "../../src/project/instance"
 import { Session } from "../../src/session"
@@ -356,6 +358,72 @@ describe("server.routes.agent-studio", () => {
           expect(metadataResponse.status).toBe(200)
           expect(metadata.acceptance.ok).toBe(true)
           expect(metadata.acceptance.messageCount).toBe(2)
+        },
+      })
+    } finally {
+      restore(home)
+    }
+  })
+
+  test("publishes workflow completed event after CPIII acceptance passes", async () => {
+    await using tmp = await tmpdir()
+    const home = process.env.RAILWISE_TEST_HOME
+    process.env.RAILWISE_TEST_HOME = tmp.path
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await Session.create({ title: "CPIII completion event" })
+          const md = "wiki/changes/format-coverage-2026-04-30.md"
+          const json = "wiki/changes/format-coverage-2026-04-30.json"
+          const events: { workflowId: string; sessionId: string; durationMs: number }[] = []
+          const unsub = Bus.subscribe(WorkflowCompleted, (event) => events.push(event.properties))
+
+          try {
+            const user = await writeUser(
+              session.id,
+              `工作流附件：\n- 格式兼容性质检报告 Markdown: ${md}\n- 格式兼容性质检报告 JSON: ${json}`,
+            )
+            await writeAssistant(
+              session.id,
+              user.id,
+              [
+                "# CPIII 复测预案",
+                "",
+                "## 附件引用",
+                `- 格式兼容性质检报告 Markdown: ${md}`,
+                `- 格式兼容性质检报告 JSON: ${json}`,
+                "",
+                "## 规范引用",
+                "- wiki_page_path: wiki/clauses/cpiii-precision.md",
+                "- raw_source_md: raw/tb10601.md",
+                "- norm_clause_id: TB10601-3.1",
+                "",
+                "## 工具结果摘要",
+                "- 格式样本 6/6 可用，warning 2 条。",
+                "- sigma0、残差、自由网、粗差、稳健、方差分量、条件平差均已汇总。",
+              ].join("\n"),
+            )
+
+            const response = await AgentStudioRoutes().request("http://railwise.test/workflow/acceptance", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ workflowId: "cpiii-resurvey-wiki", sessionId: session.id }),
+            })
+            const result = (await response.json()) as { ok: boolean }
+
+            expect(response.status).toBe(200)
+            expect(result.ok).toBe(true)
+            expect(events).toHaveLength(1)
+            expect(events[0]).toEqual({
+              workflowId: "cpiii-resurvey-wiki",
+              sessionId: session.id,
+              durationMs: expect.any(Number),
+            })
+            expect(events[0]?.durationMs).toBeGreaterThanOrEqual(0)
+          } finally {
+            unsub()
+          }
         },
       })
     } finally {


### PR DESCRIPTION
## Summary
- publish agent.workflow.completed after workflow acceptance passes
- add a CPIII acceptance regression test for WorkflowCompleted events

## Verification
- cd packages/railwise && bun test --timeout 30000 test/server/agent-studio.test.ts test/agent/railwise-v2.test.ts test/agent/agent.test.ts test/cli/workflow.test.ts test/cli/workflow-cli.test.ts
- cd packages/railwise && bun run typecheck
- git diff --check
- pre-push hook: bun turbo typecheck