### PR TITLE
feat(app): refresh workflow completion state

### DIFF
--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -174,6 +174,7 @@ export function createChildStoreManager(input: {
             mcp: {},
             lsp: [],
             vcs: vcsStore.value,
+            workflow_completion: {},
             limit: 5,
             message: {},
             part: {},

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -78,6 +78,7 @@ const baseState = (input: Partial<State> = {}) =>
     mcp: {},
     lsp: [],
     vcs: undefined,
+    workflow_completion: {},
     limit: 10,
     message: {},
     part: {},
@@ -457,6 +458,36 @@ describe("applyDirectoryEvent", () => {
 
     expect(store.vcs).toEqual({ branch: "feature/test" })
     expect(cacheStore.value).toEqual({ branch: "feature/test" })
+  })
+
+  test("records completed workflow events and refreshes the directory", () => {
+    const [store, setStore] = createStore(baseState())
+    const pushes: string[] = []
+
+    applyDirectoryEvent({
+      event: {
+        type: "agent.workflow.completed",
+        properties: {
+          workflowId: "cpiii-resurvey-wiki",
+          sessionId: "ses_1",
+          durationMs: 2400,
+        },
+      },
+      store,
+      setStore,
+      push(directory) {
+        pushes.push(directory)
+      },
+      directory: "/tmp/project",
+      loadLsp() {},
+    })
+
+    expect(store.workflow_completion.ses_1).toEqual({
+      workflowId: "cpiii-resurvey-wiki",
+      sessionId: "ses_1",
+      durationMs: 2400,
+    })
+    expect(pushes).toEqual(["/tmp/project"])
   })
 
   test("routes disposal and lsp events to side-effect handlers", () => {

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -52,7 +52,8 @@ function cleanupSessionCaches(
     store.todo[sessionID] !== undefined ||
     store.permission[sessionID] !== undefined ||
     store.question[sessionID] !== undefined ||
-    store.session_status[sessionID] !== undefined
+    store.session_status[sessionID] !== undefined ||
+    store.workflow_completion[sessionID] !== undefined
   setSessionTodo?.(sessionID, undefined)
   if (!hasAny) return
   setStore(
@@ -71,6 +72,7 @@ function cleanupSessionCaches(
       delete draft.permission[sessionID]
       delete draft.question[sessionID]
       delete draft.session_status[sessionID]
+      delete draft.workflow_completion[sessionID]
     }),
   )
 }
@@ -263,6 +265,17 @@ export function applyDirectoryEvent(input: {
       const next = { branch: props.branch }
       input.setStore("vcs", next)
       if (input.vcsCache) input.vcsCache.setStore("value", next)
+      break
+    }
+    case "agent.workflow.completed": {
+      const props = event.properties as { workflowId: string; sessionId: string; durationMs: number }
+      if (!props.sessionId) break
+      input.setStore("workflow_completion", props.sessionId, {
+        workflowId: props.workflowId,
+        sessionId: props.sessionId,
+        durationMs: props.durationMs,
+      })
+      input.push(input.directory)
       break
     }
     case "permission.asked": {

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -31,6 +31,12 @@ export type ProjectMeta = {
   }
 }
 
+export type WorkflowCompletion = {
+  workflowId: string
+  sessionId: string
+  durationMs: number
+}
+
 export type State = {
   status: "loading" | "partial" | "complete"
   agent: Agent[]
@@ -63,6 +69,9 @@ export type State = {
   }
   lsp: LspStatus[]
   vcs: VcsInfo | undefined
+  workflow_completion: {
+    [sessionID: string]: WorkflowCompletion
+  }
   limit: number
   message: {
     [sessionID: string]: Message[]

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -131,6 +131,16 @@ export function SessionComposerRegion(props: {
   const workflowStepIndex = createMemo(() => workflowSteps.findIndex((step) => step.id === workflowStage()))
   const failedChecks = createMemo(() => acceptance()?.checks.filter((item) => item.status === "fail") ?? [])
 
+  const loadWorkflowSession = (id: string) =>
+    api
+      .workflowSession(id)
+      .then((info) => {
+        if (params.id !== id) return
+        setStored(info)
+        setAcceptance(info.acceptance)
+      })
+      .catch(() => {})
+
   createEffect(() => {
     const id = params.id
     sessionKey()
@@ -139,14 +149,14 @@ export function SessionComposerRegion(props: {
     setAcceptanceError("")
     setArtifactNotice("")
     if (!id) return
-    void api
-      .workflowSession(id)
-      .then((info) => {
-        if (params.id !== id) return
-        setStored(info)
-        setAcceptance(info.acceptance)
-      })
-      .catch(() => {})
+    void loadWorkflowSession(id)
+  })
+
+  createEffect(() => {
+    const id = params.id
+    const completed = id ? sync.data.workflow_completion[id] : undefined
+    if (!id || !completed) return
+    void loadWorkflowSession(id)
   })
 
   createEffect(() => {


### PR DESCRIPTION
## Summary
- add App sync state for completed workflow events
- handle agent.workflow.completed by recording session completion and refreshing the directory
- reload workflow session metadata in the session composer when completion arrives

## Tests
- cd packages/app && bun test --preload ./happydom.ts ./src/context/global-sync
- cd packages/app && bun test --preload ./happydom.ts ./src/pages/session/composer/workflow-delivery.test.ts ./src/components/workflow-canvas.test.tsx
- cd packages/app && bun run typecheck
- git diff --check

Pre-push hook also ran bun turbo typecheck.