### PR TITLE
feat(app): show workflow completion status

### DIFF
--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -20,6 +20,7 @@ import {
   deliveryMissingCount,
   deliveryRows,
   deliveryStatus,
+  workflowCompletionSummary,
 } from "@/pages/session/composer/workflow-delivery"
 import type { WorkflowAcceptance, WorkflowRunArtifact, WorkflowSession } from "@/types/agent-studio"
 
@@ -101,6 +102,7 @@ export function SessionComposerRegion(props: {
   )
   const artifacts = createMemo(() => handoff()?.artifacts ?? stored()?.artifacts ?? [])
   const delivery = createMemo(() => stored()?.delivery)
+  const completion = createMemo(() => (params.id ? sync.data.workflow_completion[params.id] : undefined))
   const canAccept = createMemo(() => Boolean(params.id && workflowId() === "cpiii-resurvey-wiki"))
 
   const previewPrompt = () =>
@@ -130,6 +132,18 @@ export function SessionComposerRegion(props: {
   })
   const workflowStepIndex = createMemo(() => workflowSteps.findIndex((step) => step.id === workflowStage()))
   const failedChecks = createMemo(() => acceptance()?.checks.filter((item) => item.status === "fail") ?? [])
+  const deliveryMissing = createMemo(() => {
+    const item = delivery()
+    if (!item) return undefined
+    return deliveryMissingCount(item)
+  })
+  const completionSummary = createMemo(() =>
+    workflowCompletionSummary({
+      completion: completion(),
+      delivery: delivery(),
+      acceptanceOk: acceptance()?.ok,
+    }),
+  )
 
   const loadWorkflowSession = (id: string) =>
     api
@@ -154,7 +168,7 @@ export function SessionComposerRegion(props: {
 
   createEffect(() => {
     const id = params.id
-    const completed = id ? sync.data.workflow_completion[id] : undefined
+    const completed = completion()
     if (!id || !completed) return
     void loadWorkflowSession(id)
   })
@@ -415,6 +429,23 @@ export function SessionComposerRegion(props: {
                         </Show>
                         <Show when={acceptanceError()}>
                           {(message) => <span class="text-text-danger-base truncate">{message()}</span>}
+                        </Show>
+                        <Show when={completionSummary()}>
+                          {(message) => (
+                            <span
+                              classList={{
+                                "max-w-full truncate rounded-sm px-1.5 py-0.5 text-11-regular": true,
+                                "bg-[rgba(31,118,71,0.08)] text-[rgb(31,118,71)]":
+                                  acceptance()?.ok && deliveryMissing() === 0,
+                                "bg-[rgba(160,42,42,0.06)] text-text-danger-base":
+                                  (deliveryMissing() ?? 0) > 0,
+                                "bg-surface-base text-text-weak": deliveryMissing() === undefined,
+                              }}
+                              title={message()}
+                            >
+                              {message()}
+                            </span>
+                          )}
                         </Show>
                       </div>
                       <button

--- a/packages/app/src/pages/session/composer/workflow-delivery.test.ts
+++ b/packages/app/src/pages/session/composer/workflow-delivery.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import type { WorkflowDeliveryArchive } from "@/types/agent-studio"
 import {
+  completionDuration,
   deliveryFileCount,
   deliveryFiles,
   deliveryMissingCount,
   deliveryRows,
   deliveryStatus,
+  workflowCompletionSummary,
 } from "./workflow-delivery"
 
 const archive: WorkflowDeliveryArchive = {
@@ -80,5 +82,32 @@ describe("workflow delivery helpers", () => {
     expect(deliveryFileCount(broken)).toBe(2)
     expect(deliveryMissingCount(broken)).toBe(1)
     expect(deliveryStatus(broken)).toBe("缺失 1 个文件")
+  })
+
+  test("formats workflow completion duration for status chips", () => {
+    expect(completionDuration({ workflowId: "cpiii-resurvey-wiki", sessionId: "ses_demo", durationMs: 2400 })).toBe(
+      "2.4 秒",
+    )
+    expect(completionDuration({ workflowId: "cpiii-resurvey-wiki", sessionId: "ses_demo", durationMs: 121000 })).toBe(
+      "2 分 01 秒",
+    )
+  })
+
+  test("builds completion summaries with delivery state", () => {
+    const completion = { workflowId: "cpiii-resurvey-wiki", sessionId: "ses_demo", durationMs: 2400 }
+
+    expect(workflowCompletionSummary({ completion, acceptanceOk: true })).toBe("已完成 · 2.4 秒 · 待导出交付包")
+    expect(workflowCompletionSummary({ completion, delivery: archive, acceptanceOk: true })).toBe(
+      "已完成 · 2.4 秒 · 交付包完整 4 个文件",
+    )
+
+    const broken: WorkflowDeliveryArchive = {
+      ...archive,
+      files: archive.files?.map((file) => (file.kind === "artifact" ? { ...file, copied: false } : file)),
+    }
+
+    expect(workflowCompletionSummary({ completion, delivery: broken, acceptanceOk: true })).toBe(
+      "已完成 · 2.4 秒 · 交付包缺失 1 个文件",
+    )
   })
 })

--- a/packages/app/src/pages/session/composer/workflow-delivery.ts
+++ b/packages/app/src/pages/session/composer/workflow-delivery.ts
@@ -2,6 +2,12 @@ import type { WorkflowDeliveryArchive } from "@/types/agent-studio"
 
 type DeliveryFile = NonNullable<WorkflowDeliveryArchive["files"]>[number]
 
+export type WorkflowCompletionStatus = {
+  workflowId: string
+  sessionId: string
+  durationMs: number
+}
+
 export type DeliveryPathRow = {
   label: string
   path: string
@@ -60,6 +66,31 @@ export function deliveryStatus(item: WorkflowDeliveryArchive) {
   const missing = deliveryMissingCount(item)
   if (missing) return `缺失 ${missing} 个文件`
   return `完整 · ${deliveryFileCount(item)} 个文件`
+}
+
+export function completionDuration(item: WorkflowCompletionStatus | undefined) {
+  if (!item) return undefined
+  const seconds = Math.max(0, item.durationMs) / 1000
+  if (seconds < 60) {
+    const rounded = Math.round(seconds * 10) / 10
+    return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)} 秒`
+  }
+  const minutes = Math.floor(seconds / 60)
+  const rest = Math.floor(seconds % 60)
+  return `${minutes} 分 ${rest.toString().padStart(2, "0")} 秒`
+}
+
+export function workflowCompletionSummary(input: {
+  completion?: WorkflowCompletionStatus
+  delivery?: WorkflowDeliveryArchive
+  acceptanceOk?: boolean
+}) {
+  if (!input.completion && !input.acceptanceOk) return undefined
+  const base = input.completion ? ["已完成", completionDuration(input.completion)].filter(Boolean).join(" · ") : "已通过"
+  if (!input.delivery) return `${base} · 待导出交付包`
+  const missing = deliveryMissingCount(input.delivery)
+  if (missing) return `${base} · 交付包缺失 ${missing} 个文件`
+  return `${base} · 交付包完整 ${deliveryFileCount(input.delivery)} 个文件`
 }
 
 function fileLabel(kind: DeliveryFile["kind"]) {


### PR DESCRIPTION
## Summary
- add tested helpers for workflow completion duration and delivery-state summaries
- show completion status in the session workflow acceptance panel
- distinguish pending export, complete delivery package, and missing delivery files

## Tests
- cd packages/app && bun test --preload ./happydom.ts ./src/pages/session/composer/workflow-delivery.test.ts ./src/context/global-sync
- cd packages/app && bun run typecheck
- git diff --check

Pre-push hook also ran bun turbo typecheck.