### PR TITLE
refactor(app): split prompt input dock styles

### DIFF
--- a/packages/app/src/components/prompt-input.css
+++ b/packages/app/src/components/prompt-input.css
@@ -1,0 +1,64 @@
+[data-component="prompt-input-region"] {
+  position: relative;
+  display: flex;
+  width: 100%;
+  height: 100%;
+  max-height: 320px;
+  flex-direction: column;
+  gap: 0;
+}
+
+[data-component="prompt-input-shell"]:focus-within {
+  box-shadow: var(--shadow-xs-border);
+}
+
+[data-component="prompt-input-tray"] {
+  [data-slot="prompt-input-tray-inner"] {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    padding: 22px 7px 8px;
+  }
+
+  [data-slot="prompt-input-tray-primary"] {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  [data-slot="prompt-input-shell-mode"] {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    max-width: 160px;
+    min-width: 0;
+    height: 28px;
+    padding: 0 4px 0 8px;
+  }
+
+  [data-slot="prompt-input-shell-mode-label"] {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--text-strong);
+    font-family: var(--font-family-sans);
+    font-size: 13px;
+    font-weight: var(--font-weight-medium);
+    line-height: var(--line-height-large);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  [data-slot="prompt-input-shell-mode-spacer"] {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+  }
+
+  [data-slot="prompt-input-mode-switch"] {
+    flex-shrink: 0;
+  }
+}

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -53,6 +53,7 @@ import { PromptDragOverlay } from "./prompt-input/drag-overlay"
 import { promptPlaceholder } from "./prompt-input/placeholder"
 import { ImagePreview } from "@railwise/ui/image-preview"
 import { agentColor } from "@/utils/agent"
+import "./prompt-input.css"
 
 interface PromptInputProps {
   class?: string
@@ -1157,7 +1158,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const variants = createMemo(() => ["default", ...local.model.variant.list()])
 
   return (
-    <div class="relative size-full _max-h-[320px] flex flex-col gap-0">
+    <div data-component="prompt-input-region">
       <PromptPopover
         popover={store.popover}
         setSlashPopoverRef={(el) => (slashPopoverRef = el)}
@@ -1174,10 +1175,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         t={(key) => language.t(key as Parameters<typeof language.t>[0])}
       />
       <DockShellForm
+        data-component="prompt-input-shell"
         onSubmit={handleSubmit}
         classList={{
           "group/prompt-input": true,
-          "focus-within:shadow-xs-border": true,
           "border-icon-info-active border-dashed": store.draggingType !== null,
           [props.class ?? ""]: !!props.class,
         }}
@@ -1420,13 +1421,13 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         </div>
       </DockShellForm>
       <Show when={store.mode === "normal" || store.mode === "shell"}>
-        <DockTray attach="top">
-          <div class="px-1.75 pt-5.5 pb-2 flex items-center gap-2 min-w-0">
-            <div class="flex items-center gap-1.5 min-w-0 flex-1">
+        <DockTray attach="top" data-component="prompt-input-tray">
+          <div data-slot="prompt-input-tray-inner">
+            <div data-slot="prompt-input-tray-primary">
               <Show when={store.mode === "shell"}>
-                <div class="h-7 flex items-center gap-1.5 max-w-[160px] min-w-0" style={{ padding: "0 4px 0 8px" }}>
-                  <span class="truncate text-13-medium text-text-strong">{language.t("prompt.mode.shell")}</span>
-                  <div class="size-4 shrink-0" />
+                <div data-slot="prompt-input-shell-mode">
+                  <span data-slot="prompt-input-shell-mode-label">{language.t("prompt.mode.shell")}</span>
+                  <div data-slot="prompt-input-shell-mode-spacer" />
                 </div>
               </Show>
               <Show when={store.mode === "normal"}>
@@ -1528,7 +1529,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                 </TooltipKeybind>
               </Show>
             </div>
-            <div class="shrink-0">
+            <div data-slot="prompt-input-mode-switch">
               <RadioGroup
                 options={["shell", "normal"] as const}
                 current={store.mode}


### PR DESCRIPTION
## Summary
- Move PromptInput outer region, focus shadow, tray layout, and shell-mode label styles into a local CSS file.
- Keep editor, button, selector, and submit behavior unchanged.

## Verification
- cd packages/app && bun run typecheck
- cd packages/app && bun test:e2e:local -- e2e/prompt/prompt.spec.ts e2e/prompt/prompt-multiline.spec.ts e2e/commands/input-focus.spec.ts e2e/session/session-composer-dock.spec.ts
- pre-push turbo typecheck passed