### PR TITLE
refactor(ui): attach dock prompt footers

### DIFF
--- a/packages/ui/src/components/dock-prompt.css
+++ b/packages/ui/src/components/dock-prompt.css
@@ -94,8 +94,7 @@
     align-items: center;
     justify-content: space-between;
     flex-shrink: 0;
-    padding: 32px 8px 8px;
-    margin-top: -24px;
+    padding: 22px 8px 8px;
   }
 
   [data-slot="permission-footer-actions"] {

--- a/packages/ui/src/components/dock-prompt.tsx
+++ b/packages/ui/src/components/dock-prompt.tsx
@@ -16,7 +16,9 @@ export function DockPrompt(props: {
         <div data-slot={slot("header")}>{props.header}</div>
         <div data-slot={slot("content")}>{props.children}</div>
       </DockShell>
-      <DockTray data-slot={slot("footer")}>{props.footer}</DockTray>
+      <DockTray attach="top" data-slot={slot("footer")}>
+        {props.footer}
+      </DockTray>
     </div>
   )
 }

--- a/packages/ui/src/components/question-prompt.css
+++ b/packages/ui/src/components/question-prompt.css
@@ -296,8 +296,7 @@
     align-items: center;
     justify-content: space-between;
     flex-shrink: 0;
-    padding: 32px 8px 8px;
-    margin-top: -24px;
+    padding: 22px 8px 8px;
   }
 
   [data-slot="question-footer-actions"] {


### PR DESCRIPTION
## Summary
- Use the shared DockTray attached state for DockPrompt footers.
- Replace question/permission footer negative margins with equivalent attached-tray padding.

## Verification
- cd packages/ui && bun run typecheck
- cd packages/app && bun run typecheck
- cd packages/app && bun test:e2e:local -- e2e/session/session-composer-dock.spec.ts
- pre-push turbo typecheck passed