### PR TITLE
refactor(app): move prompt trigger styles

### DIFF
--- a/packages/app/src/components/prompt-input.css
+++ b/packages/app/src/components/prompt-input.css
@@ -58,6 +58,15 @@
     flex-shrink: 0;
   }
 
+  [data-slot="prompt-input-model-trigger"] {
+    height: 28px;
+  }
+
+  [data-slot="prompt-input-provider-icon"] {
+    transform: translateZ(0);
+    will-change: opacity;
+  }
+
   [data-slot="prompt-input-mode-switch"] {
     flex-shrink: 0;
   }

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1459,17 +1459,17 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                     >
                       <Button
                         as="div"
+                        data-slot="prompt-input-model-trigger"
                         variant="ghost"
                         size="normal"
                         class="min-w-0 max-w-[320px] text-13-regular group"
-                        style={{ height: "28px" }}
                         onClick={() => dialog.show(() => <DialogSelectModelUnpaid />)}
                       >
                         <Show when={local.model.current()?.provider?.id}>
                           <ProviderIcon
+                            data-slot="prompt-input-provider-icon"
                             id={local.model.current()!.provider.id as IconName}
                             class="size-4 shrink-0 opacity-40 group-hover:opacity-100 transition-opacity duration-150"
-                            style={{ "will-change": "opacity", transform: "translateZ(0)" }}
                           />
                         </Show>
                         <span class="truncate">
@@ -1491,15 +1491,15 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                       triggerProps={{
                         variant: "ghost",
                         size: "normal",
-                        style: { height: "28px" },
+                        "data-slot": "prompt-input-model-trigger",
                         class: "min-w-0 max-w-[320px] text-13-regular group",
                       }}
                     >
                       <Show when={local.model.current()?.provider?.id}>
                         <ProviderIcon
+                          data-slot="prompt-input-provider-icon"
                           id={local.model.current()!.provider.id as IconName}
                           class="size-4 shrink-0 opacity-40 group-hover:opacity-100 transition-opacity duration-150"
-                          style={{ "will-change": "opacity", transform: "translateZ(0)" }}
                         />
                       </Show>
                       <span class="truncate">


### PR DESCRIPTION
## Summary
- Move PromptInput model trigger height styling into prompt-input.css.
- Move ProviderIcon opacity animation hints into prompt-input.css.
- Keep Select triggerStyle props unchanged to avoid changing the Select API path.

## Verification
- cd packages/app && bun run typecheck
- cd packages/app && bun test:e2e:local -- e2e/prompt/prompt.spec.ts e2e/prompt/prompt-multiline.spec.ts e2e/commands/input-focus.spec.ts e2e/session/session-composer-dock.spec.ts
- pre-push turbo typecheck passed