### PR TITLE
refactor(app): move prompt select trigger styles

### DIFF
--- a/packages/app/src/components/prompt-input.css
+++ b/packages/app/src/components/prompt-input.css
@@ -62,6 +62,10 @@
     height: 28px;
   }
 
+  .prompt-input-tray-select[data-slot="select-select-trigger"] {
+    height: 28px;
+  }
+
   [data-slot="prompt-input-provider-icon"] {
     transform: translateZ(0);
     will-change: opacity;

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1442,9 +1442,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                     options={agentNames()}
                     current={local.agent.current()?.name ?? ""}
                     onSelect={local.agent.set}
-                    class="capitalize max-w-[160px]"
+                    class="prompt-input-tray-select capitalize max-w-[160px]"
                     valueClass="truncate text-13-regular"
-                    triggerStyle={{ height: "28px" }}
                     variant="ghost"
                   />
                 </TooltipKeybind>
@@ -1521,9 +1520,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                     current={local.model.variant.current() ?? "default"}
                     label={(x) => (x === "default" ? language.t("common.default") : x)}
                     onSelect={(x) => local.model.variant.set(x === "default" ? undefined : x)}
-                    class="capitalize max-w-[160px]"
+                    class="prompt-input-tray-select capitalize max-w-[160px]"
                     valueClass="truncate text-13-regular"
-                    triggerStyle={{ height: "28px" }}
                     variant="ghost"
                   />
                 </TooltipKeybind>

--- a/specs/session-composer-refactor-plan.md
+++ b/specs/session-composer-refactor-plan.md
@@ -24,10 +24,10 @@ Status as of 2026-05-04:
 - The old global `packages/app/src/components/session-todo-dock.tsx` implementation has been deleted.
 - Targeted typecheck and composer/prompt e2e suites were kept green across the incremental PRs. A full local `bun test:e2e:local` remains a release gate, not a per-slice requirement.
 - The old-named `session-prompt-dock.test.ts` helper test has been renamed to `session-prompt-helpers.test.ts`.
+- PromptInput Select trigger height was kept local to `prompt-input.css`; no shared Select sizing API was introduced because the remaining 28px rule is prompt-tray specific.
 
 Remaining follow-ups:
 
-- Decide whether the two remaining inline `Select triggerStyle={{ height: "28px" }}` usages in `PromptInput` justify a shared Select sizing API.
 - Consider the optional shared question/permission presentational extraction only if it stays small and remains covered by the composer dock e2e suite.
 
 ## Decisions Up Front
@@ -221,7 +221,7 @@ Implemented:
 - `DockPrompt` wraps body/footer with `DockShell` / `DockTray`.
 - `PromptInput` wraps the top form and bottom bar with `DockShellForm` / `DockTray`.
 - `SessionTodoDock` uses `DockTray` and keeps todo-specific rules in `session-todo-dock.css`.
-- Prompt model trigger and provider-icon animation hints were moved into `prompt-input.css`; two small Select height overrides remain inline pending a specific Select API decision.
+- Prompt model trigger, prompt Select trigger height, and provider-icon animation hints were moved into `prompt-input.css`.
 
 ### 2.3 De-risk style ownership
 
@@ -269,8 +269,7 @@ Deferred:
 
 Open micro-slices:
 
-1. Decide whether Select needs a size/class API for prompt model triggers.
-2. Run the full local e2e suite before GA/release candidate packaging.
+1. Run the full local e2e suite before GA/release candidate packaging.
 
 ---
 


### PR DESCRIPTION
## Summary
- move prompt tray Select trigger height from inline `triggerStyle` to `prompt-input.css`
- keep Select API unchanged because the remaining 28px height rule is prompt-tray specific
- update the Session Composer refactor plan to record the decision

## Release note
- Desktop release status checked: the latest successful Desktop Release run produced macOS build-preflight draft assets only; it skipped notarization, so it is internal validation output, not GA.

## Verification
- cd packages/app && bun run typecheck
- git diff --check
- cd packages/app && bun test:e2e:local -- e2e/prompt/prompt.spec.ts e2e/prompt/prompt-multiline.spec.ts e2e/commands/input-focus.spec.ts e2e/session/session-composer-dock.spec.ts
- pre-push: bun turbo typecheck