### PR TITLE
ci(desktop): allow unsigned windows internal build

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -29,6 +29,11 @@ on:
         required: true
         default: false
         type: boolean
+      windows_unsigned_internal:
+        description: "仅 Windows 内测：跳过 SignPath 签名，只上传未签名安装包 artifact"
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -114,6 +119,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           MACOS_SKIP_NOTARIZATION: ${{ github.event_name == 'workflow_dispatch' && inputs.macos_skip_notarization || false }}
+          WINDOWS_UNSIGNED_INTERNAL: ${{ github.event_name == 'workflow_dispatch' && inputs.windows_unsigned_internal || false }}
         run: |
           missing=()
           for secret in TAURI_SIGNING_PRIVATE_KEY TAURI_SIGNING_PRIVATE_KEY_PASSWORD; do
@@ -129,7 +135,7 @@ jobs:
               done
             fi
           fi
-          if [ "${{ matrix.platform }}" = "windows" ]; then
+          if [ "${{ matrix.platform }}" = "windows" ] && [ "$WINDOWS_UNSIGNED_INTERNAL" != "true" ]; then
             for secret in SIGNPATH_API_TOKEN SIGNPATH_ORG_ID; do
               if [ -z "${!secret}" ]; then missing+=("$secret"); fi
             done
@@ -188,8 +194,8 @@ jobs:
           fi
           bun run --cwd packages/desktop tauri -- "${args[@]}"
 
-      - name: Upload unsigned Windows installer
-        if: matrix.platform == 'windows'
+      - name: Upload unsigned Windows installer for signing
+        if: matrix.platform == 'windows' && (github.event_name != 'workflow_dispatch' || inputs.windows_unsigned_internal != true)
         id: upload_unsigned_windows
         uses: actions/upload-artifact@v7
         with:
@@ -199,8 +205,19 @@ jobs:
             packages/desktop/src-tauri/target/release/bundle/nsis/*.exe
           if-no-files-found: error
 
+      - name: Upload internal unsigned Windows installer
+        if: matrix.platform == 'windows' && github.event_name == 'workflow_dispatch' && inputs.windows_unsigned_internal == true
+        uses: actions/upload-artifact@v7
+        with:
+          name: railwise-desktop-windows-x64-internal-${{ inputs.version }}
+          path: |
+            packages/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
+            packages/desktop/src-tauri/target/release/bundle/nsis/*.exe
+          if-no-files-found: error
+          retention-days: 14
+
       - name: Sign Windows Installer (SignPath)
-        if: matrix.platform == 'windows'
+        if: matrix.platform == 'windows' && (github.event_name != 'workflow_dispatch' || inputs.windows_unsigned_internal != true)
         uses: signpath/github-action-submit-signing-request@v1
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -212,7 +229,7 @@ jobs:
           output-artifact-directory: dist/signed
 
       - name: Upload signed Windows installer
-        if: matrix.platform == 'windows'
+        if: matrix.platform == 'windows' && (github.event_name != 'workflow_dispatch' || inputs.windows_unsigned_internal != true)
         uses: actions/upload-artifact@v7
         with:
           name: railwise-desktop-${{ matrix.target }}-signed
@@ -220,6 +237,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload bundle artifacts
+        if: matrix.platform != 'windows' || github.event_name != 'workflow_dispatch' || inputs.windows_unsigned_internal != true
         uses: actions/upload-artifact@v7
         with:
           name: railwise-desktop-${{ matrix.target }}
@@ -233,6 +251,7 @@ jobs:
     name: Create draft release
     runs-on: ubuntu-22.04
     needs: build
+    if: github.event_name != 'workflow_dispatch' || inputs.windows_unsigned_internal != true
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v8

--- a/scripts/verify-desktop-windows-internal.ts
+++ b/scripts/verify-desktop-windows-internal.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env bun
+
+import path from "node:path"
+
+const root = path.resolve(import.meta.dir, "..")
+const checks: { name: string; passed: boolean; detail: string }[] = []
+const file = (...parts: string[]) => path.join(root, ...parts)
+const read = async (...parts: string[]) => Bun.file(file(...parts)).text()
+const exists = async (...parts: string[]) => Bun.file(file(...parts)).exists()
+const has = (text: string, values: string[]) => values.every((value) => text.includes(value))
+const check = (name: string, passed: boolean, detail: string) => checks.push({ name, passed, detail })
+
+const workflowPath = ".github/workflows/desktop-release.yml"
+const configPath = "packages/desktop/src-tauri/tauri.prod.conf.json"
+const workflow = (await exists(workflowPath)) ? await read(workflowPath) : ""
+const config = await Bun.file(file(configPath)).json()
+
+check("release workflow exists", Boolean(workflow), workflowPath)
+check(
+  "windows internal input",
+  has(workflow, ["windows_unsigned_internal", "仅 Windows 内测", "default: false"]),
+  "manual release dispatch exposes an unsigned Windows internal switch",
+)
+check(
+  "windows-only internal target",
+  has(workflow, ["platform:", "- windows", "x86_64-pc-windows-msvc", "windows-2022"]),
+  "manual platform=windows builds the single Windows x64 target",
+)
+check(
+  "signpath skipped for internal",
+  has(workflow, [
+    "WINDOWS_UNSIGNED_INTERNAL",
+    '[ "${{ matrix.platform }}" = "windows" ] && [ "$WINDOWS_UNSIGNED_INTERNAL" != "true" ]',
+    "inputs.windows_unsigned_internal != true",
+  ]),
+  "internal Windows builds do not require SignPath secrets or signing steps",
+)
+check(
+  "internal artifact",
+  has(workflow, [
+    "Upload internal unsigned Windows installer",
+    "railwise-desktop-windows-x64-internal-${{ inputs.version }}",
+    "release/bundle/nsis/*.exe",
+    "retention-days: 14",
+  ]),
+  "internal build uploads a short-lived NSIS installer artifact",
+)
+check(
+  "release skipped for internal",
+  has(workflow, [
+    "Create draft release",
+    "if: github.event_name != 'workflow_dispatch' || inputs.windows_unsigned_internal != true",
+  ]),
+  "unsigned internal installer is not published as a GitHub Release",
+)
+check(
+  "windows installer config",
+  config.bundle?.windows?.nsis?.installerIcon === "icons/railwise/icon.ico" &&
+    config.bundle?.windows?.nsis?.headerImage === "assets/nsis-header-railwise.bmp" &&
+    config.bundle?.windows?.nsis?.sidebarImage === "assets/nsis-sidebar-railwise.bmp" &&
+    config.bundle?.windows?.nsis?.languages?.includes("SimpChinese") === true,
+  "NSIS installer uses RAILWISE artwork and Simplified Chinese",
+)
+
+for (const item of checks) console.log(`${item.passed ? "[ok]" : "[fail]"} ${item.name}: ${item.detail}`)
+
+const failed = checks.filter((item) => !item.passed)
+if (failed.length) {
+  console.error(`\n${failed.length} Windows internal installer check(s) failed.`)
+  process.exit(1)
+}
+
+console.log(`\nWindows internal installer readiness passed (${checks.length} checks).`)


### PR DESCRIPTION
Adds a manual Windows internal build path for unsigned x64 NSIS installers.\n\n- Adds a workflow_dispatch flag: windows_unsigned_internal\n- Skips SignPath secret validation and signing when the flag is true\n- Uploads a short-lived internal Windows installer artifact\n- Skips GitHub Release creation for unsigned internal builds\n\nVerification:\n- bun ./scripts/verify-desktop-windows-internal.ts\n- bun run typecheck in packages/desktop\n- push hook: bun turbo typecheck