### PR TITLE
ci(desktop): use standard sidecar for windows internal builds

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -150,7 +150,18 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build sidecar
+        if: matrix.platform != 'windows' || github.event_name != 'workflow_dispatch' || inputs.windows_unsigned_internal != true
         run: bun run --cwd packages/desktop predev -- --target ${{ matrix.target }}
+
+      - name: Build internal Windows sidecar
+        if: matrix.platform == 'windows' && github.event_name == 'workflow_dispatch' && inputs.windows_unsigned_internal == true
+        shell: bash
+        run: |
+          cd packages/railwise
+          bun run build --single
+          cd ../desktop
+          mkdir -p src-tauri/sidecars
+          cp ../railwise/dist/railwise-windows-x64/bin/railwise.exe src-tauri/sidecars/railwise-cli-${{ matrix.target }}.exe
 
       - name: macOS Import Certificate
         if: matrix.platform == 'darwin'

--- a/scripts/verify-desktop-windows-internal.ts
+++ b/scripts/verify-desktop-windows-internal.ts
@@ -46,6 +46,16 @@ check(
   "internal build uploads a short-lived NSIS installer artifact",
 )
 check(
+  "internal sidecar",
+  has(workflow, [
+    "Build internal Windows sidecar",
+    "bun run build --single",
+    "railwise-windows-x64/bin/railwise.exe",
+    "railwise-cli-${{ matrix.target }}.exe",
+  ]),
+  "internal Windows builds use the standard x64 sidecar and avoid the baseline Bun download",
+)
+check(
   "release skipped for internal",
   has(workflow, [
     "Create draft release",


### PR DESCRIPTION
Fixes the Windows unsigned internal build path after CI showed the baseline Bun download failing on the Windows runner.\n\n- Keeps signed Windows release builds on the existing baseline path\n- Uses the standard railwise-windows-x64 sidecar only when windows_unsigned_internal=true\n- Preserves the unsigned internal artifact-only flow\n\nVerification:\n- bun ./scripts/verify-desktop-windows-internal.ts\n- bun run typecheck in packages/desktop\n- push hook: bun turbo typecheck