### PR TITLE
ci(desktop): build nsis for windows internal installers

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -190,6 +190,7 @@ jobs:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           MACOS_SKIP_STAPLING: ${{ github.event_name == 'workflow_dispatch' && inputs.macos_skip_stapling || false }}
           MACOS_SKIP_NOTARIZATION: ${{ github.event_name == 'workflow_dispatch' && inputs.macos_skip_notarization || false }}
+          WINDOWS_UNSIGNED_INTERNAL: ${{ github.event_name == 'workflow_dispatch' && inputs.windows_unsigned_internal || false }}
         run: |
           args=(build --ci -vv --target "${{ matrix.target }}" --config src-tauri/tauri.prod.conf.json)
           if [ "${{ matrix.platform }}" = "darwin" ]; then
@@ -202,6 +203,9 @@ jobs:
             if [ "$MACOS_SKIP_STAPLING" = "true" ]; then
               args+=(--skip-stapling)
             fi
+          fi
+          if [ "${{ matrix.platform }}" = "windows" ] && [ "$WINDOWS_UNSIGNED_INTERNAL" = "true" ]; then
+            args+=(--bundles nsis)
           fi
           bun run --cwd packages/desktop tauri -- "${args[@]}"
 

--- a/scripts/verify-desktop-windows-internal.ts
+++ b/scripts/verify-desktop-windows-internal.ts
@@ -56,6 +56,11 @@ check(
   "internal Windows builds use the standard x64 sidecar and avoid the baseline Bun download",
 )
 check(
+  "internal bundle scope",
+  has(workflow, ["WINDOWS_UNSIGNED_INTERNAL", "args+=(--bundles nsis)"]),
+  "internal Windows builds only the NSIS installer needed for testing",
+)
+check(
   "release skipped for internal",
   has(workflow, [
     "Create draft release",


### PR DESCRIPTION
Narrows unsigned Windows internal builds to the single NSIS installer we need for internal testing.\n\n- Adds --bundles nsis only when windows_unsigned_internal=true\n- Keeps formal signed Windows release behavior unchanged\n- Extends the Windows internal verification gate\n\nVerification:\n- bun ./scripts/verify-desktop-windows-internal.ts\n- bun run typecheck in packages/desktop\n- push hook: bun turbo typecheck