### PR TITLE
Sync Railwise with opencode v1.15 runtime fixes

### DIFF
--- a/docs/dev/11-opencode-v1.15-sync-audit.md
+++ b/docs/dev/11-opencode-v1.15-sync-audit.md
@@ -139,3 +139,15 @@ Generated from v1.4.5..v1.15.3.
 5. App shell: migrate prompt input, terminal websocket, global sync, and settings fixes while preserving Railwise agent studio.
 6. Validation: run package typecheck, focused tests, desktop build, and installer smoke checks.
 
+## Task 3 Config/Schema Decision
+
+Upstream v1.15.3 moved much of config and permission parsing into new `@opencode-ai/core` and Effect-based modules. Railwise does not currently have that package split, so a wholesale port would be a high-risk architecture migration rather than a safe compatibility patch.
+
+For this sync batch, Railwise ports the immediately actionable compatibility layer only:
+
+- Preserve strict validation for unknown user config fields.
+- Ignore Railwise Desktop metadata fields `version` and `system` during config validation.
+- Accept deprecated grouped `tools` config values like `{ "surveying": ["rw_chainage_convert"] }`.
+- Normalize grouped tools into boolean tool toggles so existing legacy `tools` to `permission` migration still applies.
+
+The full Effect/core config split remains a separate migration batch.

--- a/docs/dev/11-opencode-v1.15-sync-audit.md
+++ b/docs/dev/11-opencode-v1.15-sync-audit.md
@@ -173,8 +173,9 @@ For this sync batch, Railwise ports the highest-signal MCP compatibility fix fir
 - Non-schema MCP failures still mark the server failed, preserving existing error behavior.
 - Plugin SDK clients now reuse the same Basic Auth header as local server clients when `RAILWISE_SERVER_PASSWORD` is configured, preventing plugin-to-server SDK calls from failing against an authenticated local server.
 - Provider message transforms now replace lone UTF-16 surrogate code units with `U+FFFD` before request payloads are sent, matching the upstream safety fix for malformed text.
+- Tool execution now passes Zod-parsed parameters to tool handlers, so schema coercions and transforms apply before a tool runs.
 
-Remaining Task 5 work: provider request compatibility, plugin validation drift, and tool argument validation.
+Remaining Task 5 work: broader provider request compatibility and plugin validation drift.
 
 Verification for this MCP slice:
 
@@ -190,5 +191,12 @@ Verification for this plugin auth slice:
 Verification for this provider surrogate slice:
 
 - `bun test test/provider/transform.test.ts --timeout 30000`
+- `bun test test/tool test/provider test/plugin test/mcp test/server/auth.test.ts --timeout 30000`
+- `bun run typecheck`
+
+Verification for this tool validation slice:
+
+- `bun test test/tool/tool.test.ts --timeout 30000`
+- `bun test test/tool --timeout 30000`
 - `bun test test/tool test/provider test/plugin test/mcp test/server/auth.test.ts --timeout 30000`
 - `bun run typecheck`

--- a/docs/dev/11-opencode-v1.15-sync-audit.md
+++ b/docs/dev/11-opencode-v1.15-sync-audit.md
@@ -161,3 +161,21 @@ For this sync batch, Railwise ports isolated runtime fixes that fit the current 
 - Cap retry delays from `retry-after` and `retry-after-ms` headers at the runtime timer limit.
 - Retry provider API errors with 5xx status codes even when provider SDK metadata does not mark the error retryable.
 - Prefer `RAILWISE_TEST_HOME` over `RAILWISE_HOME` so server tests remain isolated when a developer shell has a real Railwise home configured.
+
+## Task 5 MCP/Tooling Decision
+
+Upstream v1.15.3 includes a broad MCP, tool, plugin, and provider rewrite that also depends on new Effect services and `@opencode-ai/core` modules. Railwise should not wholesale port that layer until the core package split is planned.
+
+For this sync batch, Railwise ports the highest-signal MCP compatibility fix first:
+
+- If `client.listTools()` fails because an external MCP server returns an invalid or unresolvable `outputSchema`, Railwise retries `tools/list` with a tolerant schema.
+- The fallback drops only the invalid output schema metadata and preserves the tool name, description, and input schema.
+- Non-schema MCP failures still mark the server failed, preserving existing error behavior.
+
+Remaining Task 5 work: provider request compatibility, plugin validation drift, and tool argument validation.
+
+Verification for this MCP slice:
+
+- `bun test test/mcp --timeout 30000`
+- `bun test test/tool test/provider test/plugin test/mcp --timeout 30000`
+- `bun run typecheck`

--- a/docs/dev/11-opencode-v1.15-sync-audit.md
+++ b/docs/dev/11-opencode-v1.15-sync-audit.md
@@ -1,0 +1,141 @@
+# opencode v1.15.3 Sync Audit
+
+Generated from v1.4.5..v1.15.3.
+
+## Summary
+
+- Changed files in scoped paths: 1169
+- Upstream package path: packages/opencode
+- Railwise package path: packages/railwise
+- Direct git merge-base with Railwise HEAD: none expected for this fork snapshot
+
+## Change Statuses
+
+| Status | Files |
+| --- | ---: |
+| M | 609 |
+| A | 426 |
+| D | 130 |
+| R | 4 |
+
+## Changed Scopes
+
+| Scope | Files |
+| --- | ---: |
+| packages/opencode | 918 |
+| packages/ui | 123 |
+| packages/app | 115 |
+| packages/sdk | 11 |
+| bun.lock | 1 |
+| package.json | 1 |
+
+## Backend Modules Changed
+
+| packages/opencode/src module | Files |
+| --- | ---: |
+| cli | 190 |
+| server | 105 |
+| tool | 45 |
+| provider | 34 |
+| util | 30 |
+| config | 25 |
+| session | 24 |
+| control-plane | 14 |
+| effect | 14 |
+| plugin | 11 |
+| project | 11 |
+| file | 7 |
+| lsp | 7 |
+| v2 | 5 |
+| agent | 4 |
+| mcp | 4 |
+| pty | 4 |
+| sync | 4 |
+| account | 3 |
+| acp | 3 |
+| bus | 3 |
+| permission | 3 |
+| skill | 3 |
+| storage | 3 |
+| command | 2 |
+| format | 2 |
+| installation | 2 |
+| question | 2 |
+| reference | 2 |
+| share | 2 |
+| audio.d.ts | 1 |
+| auth | 1 |
+| background | 1 |
+| data-migration.sql.ts | 1 |
+| data-migration.ts | 1 |
+| env | 1 |
+| event-v2-bridge.ts | 1 |
+| filesystem | 1 |
+| flag | 1 |
+| git | 1 |
+| global | 1 |
+| id | 1 |
+| ide | 1 |
+| image | 1 |
+| index.ts | 1 |
+| markdown.d.ts | 1 |
+| node.ts | 1 |
+| npm | 1 |
+| patch | 1 |
+| shell | 1 |
+| snapshot | 1 |
+| temporary.ts | 1 |
+| worktree | 1 |
+
+## App Areas Changed
+
+| packages/app/src area | Files |
+| --- | ---: |
+| context | 29 |
+| components | 28 |
+| pages | 20 |
+| i18n | 17 |
+| utils | 12 |
+| addons | 2 |
+| app.tsx | 1 |
+| entry.tsx | 1 |
+| env.d.ts | 1 |
+| index.css | 1 |
+
+## Railwise Mapping Coverage
+
+- Upstream packages/opencode changes: 918
+- Existing mapped Railwise files: 314
+- Missing mapped Railwise files: 604
+
+## Upstream Modules Missing In Railwise
+
+- account
+- background
+- control-plane
+- effect
+- git
+- image
+- reference
+- sync
+- v2
+
+## Railwise-Only Modules
+
+- bun
+- control
+- flag
+- global
+- memory
+- norm
+- scheduler
+
+## Recommended Migration Order
+
+1. Build and package scripts: keep Railwise naming, import upstream Windows/macOS build fixes only.
+2. Config and schema: migrate tolerant parsing, permission/model/schema fixes, then regenerate SDK.
+3. Server and session runtime: migrate API shape fixes, session sync, question handling, and event stream fixes.
+4. Tool/plugin/provider layer: migrate MCP/tool compatibility and provider request fixes.
+5. App shell: migrate prompt input, terminal websocket, global sync, and settings fixes while preserving Railwise agent studio.
+6. Validation: run package typecheck, focused tests, desktop build, and installer smoke checks.
+

--- a/docs/dev/11-opencode-v1.15-sync-audit.md
+++ b/docs/dev/11-opencode-v1.15-sync-audit.md
@@ -200,3 +200,27 @@ Verification for this tool validation slice:
 - `bun test test/tool --timeout 30000`
 - `bun test test/tool test/provider test/plugin test/mcp test/server/auth.test.ts --timeout 30000`
 - `bun run typecheck`
+
+## Task 6 App Shell Decision
+
+Upstream v1.15.3 changes the app shell heavily, including query-backed global sync, settings layout, terminal connection handling, and prompt input behavior. Railwise's app already diverges for the Chinese desktop shell, multi-agent hub, project/workspace flow, and desktop sidecar behavior, so this batch avoids wholesale UI replacement.
+
+For this sync batch, Railwise ports targeted app-shell stability fixes:
+
+- Workspace refresh queues now accept a normalized path key, preventing Windows slash variants such as `C:\repo` and `C:/repo` from being treated as separate queued workspaces.
+- Agent list responses are normalized defensively so array, single-object, or keyed-object payloads do not break the app shell.
+- Terminal WebSocket URLs now use `auth_token` query credentials instead of embedding username/password in the URL credential fields; the Railwise server accepts the same query token for authenticated local WebSocket requests.
+- Prompt input now preserves structured comment metadata, includes files mentioned inside comments, batches optimistic prompt state updates, and passes shell placeholder examples through the translation path.
+
+Deferred Task 6 areas:
+
+- Upstream session-cache cleanup depends on modules that Railwise does not currently carry.
+- Upstream settings-page changes are intertwined with a broader settings redesign and are deferred to avoid disrupting Railwise's current Chinese desktop settings experience.
+
+Verification for this app shell slice:
+
+- `bun test --preload ./happydom.ts ./src/context/global-sync/queue.test.ts ./src/context/global-sync/utils.test.ts ./src/utils/server.test.ts ./src/utils/terminal-websocket-url.test.ts --timeout 30000`
+- `bun test --preload ./happydom.ts ./src/components/prompt-input/build-request-parts.test.ts ./src/components/prompt-input/placeholder.test.ts ./src/components/prompt-input/submit.test.ts --timeout 30000`
+- `bun test test/server/auth.test.ts --timeout 30000`
+- `cd packages/app && bun run typecheck`
+- `cd packages/railwise && bun run typecheck`

--- a/docs/dev/11-opencode-v1.15-sync-audit.md
+++ b/docs/dev/11-opencode-v1.15-sync-audit.md
@@ -151,3 +151,13 @@ For this sync batch, Railwise ports the immediately actionable compatibility lay
 - Normalize grouped tools into boolean tool toggles so existing legacy `tools` to `permission` migration still applies.
 
 The full Effect/core config split remains a separate migration batch.
+
+## Task 4 Runtime Decision
+
+Upstream v1.15.3 replaces the old instance server layout with a new route-group HTTP API and Effect-backed session services. Railwise still has desktop-specific routes, agent studio endpoints, and sidecar assumptions on the current server structure, so a wholesale route/session port is deferred.
+
+For this sync batch, Railwise ports isolated runtime fixes that fit the current architecture:
+
+- Cap retry delays from `retry-after` and `retry-after-ms` headers at the runtime timer limit.
+- Retry provider API errors with 5xx status codes even when provider SDK metadata does not mark the error retryable.
+- Prefer `RAILWISE_TEST_HOME` over `RAILWISE_HOME` so server tests remain isolated when a developer shell has a real Railwise home configured.

--- a/docs/dev/11-opencode-v1.15-sync-audit.md
+++ b/docs/dev/11-opencode-v1.15-sync-audit.md
@@ -235,3 +235,34 @@ Verification for this SDK slice:
 - `cd packages/railwise && bun run typecheck`
 - `cd packages/desktop && bun run typecheck`
 - `cd packages/app && bun run typecheck`
+
+## Task 8 Windows Internal Installer Check
+
+The unsigned Windows internal installer path was verified through GitHub Actions after the opencode v1.15 sync slice. This confirms the beta packaging route can produce a normal Windows installer without requiring a paid Windows code-signing certificate.
+
+Workflow run:
+
+- Run: `25984425985`
+- Branch: `codex/opencode-v1.15-sync`
+- URL: `https://github.com/railwise-cn/RAILWISE-CLI/actions/runs/25984425985`
+- Version input: `1.3.0-internal.opencode-sync`
+- Platform input: `windows`
+- Internal unsigned input: `windows_unsigned_internal=true`
+
+Artifact verification:
+
+- Artifact: `railwise-desktop-windows-x64-internal-1.3.0-internal.opencode-sync`
+- Artifact id: `7040467611`
+- Downloaded zip: `/tmp/railwise-windows-internal-25984425985/artifact.zip`
+- Zip SHA256: `7f4b91754834eada7e9e1ae255614e73f06b08b45154474ab7a06d5dca1f6635`
+- Installer SHA256: `6b07c264c15d0acfce91da2c408abf70715d31c49fd46a974e25db6f4f421e18`
+- `file` output: `PE32 executable (GUI) Intel 80386, for MS Windows, Nullsoft Installer self-extracting archive`
+
+The artifact contains exactly one NSIS installer under the `x86_64-pc-windows-msvc` target path. The PE32 report is the NSIS bootstrap executable format; the artifact target and installer name are x64.
+
+Verification for this release-candidate packaging slice:
+
+- `bun ./scripts/verify-desktop-windows-internal.ts`
+- `gh workflow run desktop-release.yml --repo railwise-cn/RAILWISE-CLI --ref codex/opencode-v1.15-sync -f version=1.3.0-internal.opencode-sync -f platform=windows -f windows_unsigned_internal=true -f macos_skip_stapling=false -f macos_skip_notarization=false`
+- `gh run watch 25984425985 --repo railwise-cn/RAILWISE-CLI --exit-status`
+- `curl -L --fail --show-error --progress-bar -H "Authorization: Bearer $(gh auth token)" -H "Accept: application/vnd.github+json" https://api.github.com/repos/railwise-cn/RAILWISE-CLI/actions/artifacts/7040467611/zip -o /tmp/railwise-windows-internal-25984425985/artifact.zip`

--- a/docs/dev/11-opencode-v1.15-sync-audit.md
+++ b/docs/dev/11-opencode-v1.15-sync-audit.md
@@ -224,3 +224,14 @@ Verification for this app shell slice:
 - `bun test test/server/auth.test.ts --timeout 30000`
 - `cd packages/app && bun run typecheck`
 - `cd packages/railwise && bun run typecheck`
+
+## Task 7 SDK Regeneration Decision
+
+The JavaScript SDK was regenerated with `./packages/sdk/js/script/build.ts`. The generator completed successfully and reported no changes for the stable generated SDK files; the v2 generated files were rewritten without producing a working-tree diff.
+
+Verification for this SDK slice:
+
+- `./packages/sdk/js/script/build.ts`
+- `cd packages/railwise && bun run typecheck`
+- `cd packages/desktop && bun run typecheck`
+- `cd packages/app && bun run typecheck`

--- a/docs/dev/11-opencode-v1.15-sync-audit.md
+++ b/docs/dev/11-opencode-v1.15-sync-audit.md
@@ -171,6 +171,7 @@ For this sync batch, Railwise ports the highest-signal MCP compatibility fix fir
 - If `client.listTools()` fails because an external MCP server returns an invalid or unresolvable `outputSchema`, Railwise retries `tools/list` with a tolerant schema.
 - The fallback drops only the invalid output schema metadata and preserves the tool name, description, and input schema.
 - Non-schema MCP failures still mark the server failed, preserving existing error behavior.
+- Plugin SDK clients now reuse the same Basic Auth header as local server clients when `RAILWISE_SERVER_PASSWORD` is configured, preventing plugin-to-server SDK calls from failing against an authenticated local server.
 
 Remaining Task 5 work: provider request compatibility, plugin validation drift, and tool argument validation.
 
@@ -178,4 +179,9 @@ Verification for this MCP slice:
 
 - `bun test test/mcp --timeout 30000`
 - `bun test test/tool test/provider test/plugin test/mcp --timeout 30000`
+- `bun run typecheck`
+
+Verification for this plugin auth slice:
+
+- `bun test test/plugin test/server/auth.test.ts --timeout 30000`
 - `bun run typecheck`

--- a/docs/dev/11-opencode-v1.15-sync-audit.md
+++ b/docs/dev/11-opencode-v1.15-sync-audit.md
@@ -172,6 +172,7 @@ For this sync batch, Railwise ports the highest-signal MCP compatibility fix fir
 - The fallback drops only the invalid output schema metadata and preserves the tool name, description, and input schema.
 - Non-schema MCP failures still mark the server failed, preserving existing error behavior.
 - Plugin SDK clients now reuse the same Basic Auth header as local server clients when `RAILWISE_SERVER_PASSWORD` is configured, preventing plugin-to-server SDK calls from failing against an authenticated local server.
+- Provider message transforms now replace lone UTF-16 surrogate code units with `U+FFFD` before request payloads are sent, matching the upstream safety fix for malformed text.
 
 Remaining Task 5 work: provider request compatibility, plugin validation drift, and tool argument validation.
 
@@ -184,4 +185,10 @@ Verification for this MCP slice:
 Verification for this plugin auth slice:
 
 - `bun test test/plugin test/server/auth.test.ts --timeout 30000`
+- `bun run typecheck`
+
+Verification for this provider surrogate slice:
+
+- `bun test test/provider/transform.test.ts --timeout 30000`
+- `bun test test/tool test/provider test/plugin test/mcp test/server/auth.test.ts --timeout 30000`
 - `bun run typecheck`

--- a/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
+++ b/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
@@ -138,7 +138,7 @@ bun test test/server test/session --timeout 30000
 - Test: `packages/railwise/test/tool/**`
 - Test: `packages/railwise/test/provider/**`
 
-- [ ] **Step 1: List upstream integration changes**
+- [x] **Step 1: List upstream integration changes**
 
 ```bash
 git diff --name-status v1.4.5..v1.15.3 -- packages/opencode/src/tool packages/opencode/src/plugin packages/opencode/src/provider packages/opencode/src/mcp
@@ -148,7 +148,17 @@ git diff --name-status v1.4.5..v1.15.3 -- packages/opencode/src/tool packages/op
 
 Keep Railwise provider branding and domain tools. Port upstream fixes for MCP output schemas, provider request headers, plugin compatibility checks, and tool argument validation.
 
-- [ ] **Step 3: Run focused tests**
+Scoped progress: MCP output schema compatibility has been ported. Railwise now preserves MCP tools when an external server returns an invalid or unresolvable `outputSchema`, matching the safe fallback added upstream in opencode v1.15.3. Provider, plugin, and tool validation changes remain in this batch.
+
+- [x] **Step 3a: Run focused MCP tests**
+
+```bash
+cd packages/railwise
+bun test test/mcp --timeout 30000
+bun run typecheck
+```
+
+- [x] **Step 3b: Run focused integration tests**
 
 ```bash
 cd packages/railwise

--- a/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
+++ b/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
@@ -152,8 +152,9 @@ Scoped progress:
 
 - MCP output schema compatibility has been ported. Railwise now preserves MCP tools when an external server returns an invalid or unresolvable `outputSchema`, matching the safe fallback added upstream in opencode v1.15.3.
 - Plugin SDK client authentication headers have been ported. Railwise now reuses server Basic Auth headers for in-process plugin SDK calls when `RAILWISE_SERVER_PASSWORD` is configured.
+- Provider message surrogate sanitization has been ported. Railwise now replaces lone UTF-16 surrogate code units before provider requests are built, avoiding malformed text payloads from pasted text, OCR, or filenames.
 
-Provider and tool validation changes remain in this batch.
+Tool validation changes remain in this batch.
 
 - [x] **Step 3a: Run focused MCP tests**
 

--- a/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
+++ b/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
@@ -74,17 +74,19 @@ Expected: `dist/railwise-darwin-arm64/bin/railwise` on Apple Silicon or matching
 - Compare: `v1.15.3:packages/opencode/src/permission`
 - Test: `packages/railwise/test/config/config.test.ts`
 
-- [ ] **Step 1: List upstream config and permission changes**
+- [x] **Step 1: List upstream config and permission changes**
 
 ```bash
 git diff --name-status v1.4.5..v1.15.3 -- packages/opencode/src/config packages/opencode/src/permission
 ```
 
-- [ ] **Step 2: Port parser compatibility fixes**
+- [x] **Step 2: Port parser compatibility fixes**
 
 Preserve Railwise config paths, `.railwise` directories, and Railwise defaults. Port upstream changes for tolerant config parsing, plugin schema compatibility, permission validation, and model selection schema drift.
 
-- [ ] **Step 3: Run focused tests**
+Scoped result: full upstream config/permission rewrite depends on upstream's new `@opencode-ai/core` and Effect service split, so it is deferred to a dedicated schema migration batch. This task ports the immediately safe parser compatibility needed by Railwise Desktop: top-level desktop metadata is ignored during config validation, and deprecated grouped `tools` config is normalized into permission-compatible tool toggles.
+
+- [x] **Step 3: Run focused tests**
 
 ```bash
 cd packages/railwise

--- a/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
+++ b/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
@@ -105,17 +105,19 @@ bun test test/config/config.test.ts test/permission --timeout 30000
 - Test: `packages/railwise/test/server/**`
 - Test: `packages/railwise/test/session/**`
 
-- [ ] **Step 1: List upstream runtime changes**
+- [x] **Step 1: List upstream runtime changes**
 
 ```bash
 git diff --name-status v1.4.5..v1.15.3 -- packages/opencode/src/server packages/opencode/src/session packages/opencode/src/sync
 ```
 
-- [ ] **Step 2: Port event and HTTP API fixes**
+- [x] **Step 2: Port scoped runtime stability fixes**
 
 Preserve Railwise route naming, control-plane extensions, industry agents, and desktop sidecar assumptions. Port upstream session event shape fixes, question lifecycle fixes, SSE stability fixes, and session status handling.
 
-- [ ] **Step 3: Run focused tests**
+Scoped result: upstream v1.15.3 reorganizes the HTTP API and session services into a new route/effect architecture. That full migration is deferred. This task ports low-risk runtime stability fixes into Railwise's current structure: retry waits are capped at the runtime timer limit, provider 5xx API errors are retried even when SDK metadata omits `isRetryable`, and `RAILWISE_TEST_HOME` takes precedence over `RAILWISE_HOME` for isolated server tests.
+
+- [x] **Step 3: Run focused tests**
 
 ```bash
 cd packages/railwise

--- a/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
+++ b/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
@@ -144,7 +144,7 @@ bun test test/server test/session --timeout 30000
 git diff --name-status v1.4.5..v1.15.3 -- packages/opencode/src/tool packages/opencode/src/plugin packages/opencode/src/provider packages/opencode/src/mcp
 ```
 
-- [ ] **Step 2: Port compatibility fixes**
+- [x] **Step 2: Port compatibility fixes**
 
 Keep Railwise provider branding and domain tools. Port upstream fixes for MCP output schemas, provider request headers, plugin compatibility checks, and tool argument validation.
 
@@ -153,8 +153,9 @@ Scoped progress:
 - MCP output schema compatibility has been ported. Railwise now preserves MCP tools when an external server returns an invalid or unresolvable `outputSchema`, matching the safe fallback added upstream in opencode v1.15.3.
 - Plugin SDK client authentication headers have been ported. Railwise now reuses server Basic Auth headers for in-process plugin SDK calls when `RAILWISE_SERVER_PASSWORD` is configured.
 - Provider message surrogate sanitization has been ported. Railwise now replaces lone UTF-16 surrogate code units before provider requests are built, avoiding malformed text payloads from pasted text, OCR, or filenames.
+- Tool argument validation has been ported. Railwise now executes tools with Zod-parsed parameters, so schema coercions and transforms are applied before the tool handler runs.
 
-Tool validation changes remain in this batch.
+Remaining compatibility drift in this area is broader provider request behavior and plugin validation policy; those are deferred until the upstream core/effect split is planned.
 
 - [x] **Step 3a: Run focused MCP tests**
 
@@ -169,6 +170,15 @@ bun run typecheck
 ```bash
 cd packages/railwise
 bun test test/tool test/provider test/plugin test/mcp --timeout 30000
+```
+
+- [x] **Step 3c: Run tool validation tests**
+
+```bash
+cd packages/railwise
+bun test test/tool --timeout 30000
+bun test test/tool test/provider test/plugin test/mcp test/server/auth.test.ts --timeout 30000
+bun run typecheck
 ```
 
 ### Task 6: Desktop App Shell Batch

--- a/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
+++ b/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
@@ -199,14 +199,33 @@ bun run typecheck
 git diff --name-status v1.4.5..v1.15.3 -- packages/app/src
 ```
 
-- [ ] **Step 2: Port targeted app fixes**
+- [x] **Step 2: Port targeted app fixes**
 
 Prioritize prompt input attachment handling, terminal websocket URL generation, global sync queue/session cache fixes, settings provider fixes, and session timeline stability. Do not delete Railwise multi-agent pages or domain workflow UI.
 
-- [ ] **Step 3: Run app typecheck**
+Scoped result:
+
+- Global sync queue path normalization has been ported, including Windows path slash normalization to avoid duplicate workspace refresh entries.
+- Agent response normalization has been ported so Railwise tolerates array, single-object, and keyed-object agent payloads.
+- Terminal WebSocket URL authentication has been ported with Railwise branding and matching server-side `auth_token` support.
+- Prompt input comment metadata, mentioned-file attachment, shell placeholder, and optimistic state batching fixes have been ported.
+- Upstream session-cache and settings-page migrations are deferred because the matching modules are absent or significantly reshaped in Railwise.
+
+- [x] **Step 3: Run app typecheck**
 
 ```bash
 cd packages/app
+bun run typecheck
+```
+
+Additional verification:
+
+```bash
+cd packages/app
+bun test --preload ./happydom.ts ./src/context/global-sync/queue.test.ts ./src/context/global-sync/utils.test.ts ./src/utils/server.test.ts ./src/utils/terminal-websocket-url.test.ts --timeout 30000
+bun test --preload ./happydom.ts ./src/components/prompt-input/build-request-parts.test.ts ./src/components/prompt-input/placeholder.test.ts ./src/components/prompt-input/submit.test.ts --timeout 30000
+cd ../railwise
+bun test test/server/auth.test.ts --timeout 30000
 bun run typecheck
 ```
 

--- a/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
+++ b/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
@@ -237,13 +237,13 @@ bun run typecheck
 - Test: `packages/railwise`
 - Test: `packages/desktop`
 
-- [ ] **Step 1: Regenerate JavaScript SDK**
+- [x] **Step 1: Regenerate JavaScript SDK**
 
 ```bash
 ./packages/sdk/js/script/build.ts
 ```
 
-- [ ] **Step 2: Run package typechecks**
+- [x] **Step 2: Run package typechecks**
 
 ```bash
 cd packages/railwise
@@ -251,6 +251,8 @@ bun run typecheck
 cd ../desktop
 bun run typecheck
 ```
+
+SDK generation completed with no generated file changes.
 
 - [ ] **Step 3: Verify Windows internal installer workflow guard**
 

--- a/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
+++ b/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
@@ -254,11 +254,13 @@ bun run typecheck
 
 SDK generation completed with no generated file changes.
 
-- [ ] **Step 3: Verify Windows internal installer workflow guard**
+- [x] **Step 3: Verify Windows internal installer workflow guard**
 
 ```bash
 bun ./scripts/verify-desktop-windows-internal.ts
 ```
+
+Guard verification passed with 9 checks.
 
 ### Task 8: Release Candidate Installer Check
 
@@ -266,17 +268,20 @@ bun ./scripts/verify-desktop-windows-internal.ts
 - Modify: none unless verification exposes packaging issues
 - Test: GitHub Actions `Desktop Release`
 
-- [ ] **Step 1: Trigger unsigned Windows internal build**
+- [x] **Step 1: Trigger unsigned Windows internal build**
 
 ```bash
-gh workflow run desktop-release.yml --repo railwise-cn/RAILWISE-CLI -f version=1.3.0-internal.sync -f windows_unsigned_internal=true
+gh workflow run desktop-release.yml --repo railwise-cn/RAILWISE-CLI --ref codex/opencode-v1.15-sync -f version=1.3.0-internal.opencode-sync -f platform=windows -f windows_unsigned_internal=true -f macos_skip_stapling=false -f macos_skip_notarization=false
 ```
 
-- [ ] **Step 2: Download artifact and verify installer**
+Run 25984425985 completed successfully.
+
+- [x] **Step 2: Download artifact and verify installer**
 
 ```bash
-gh run download <run-id> --repo railwise-cn/RAILWISE-CLI --dir ~/Desktop/railwise-windows-sync-test
-find ~/Desktop/railwise-windows-sync-test -type f -iname "*.exe" -exec file {} \;
+curl -L --fail --show-error --progress-bar -H "Authorization: Bearer $(gh auth token)" -H "Accept: application/vnd.github+json" https://api.github.com/repos/railwise-cn/RAILWISE-CLI/actions/artifacts/7040467611/zip -o /tmp/railwise-windows-internal-25984425985/artifact.zip
+unzip -o /tmp/railwise-windows-internal-25984425985/artifact.zip -d /tmp/railwise-windows-internal-25984425985/extracted
+find /tmp/railwise-windows-internal-25984425985/extracted -type f -iname "*.exe" -exec file {} \; -exec shasum -a 256 {} \;
 ```
 
-Expected: Windows PE NSIS installer.
+Verified: one Windows NSIS installer for the x64 target.

--- a/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
+++ b/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
@@ -17,19 +17,19 @@
 - Create: `docs/dev/11-opencode-v1.15-sync-audit.md`
 - Modify: none
 
-- [ ] **Step 1: Run the audit script**
+- [x] **Step 1: Run the audit script**
 
 ```bash
 bun ./scripts/opencode-sync-audit.ts v1.4.5 v1.15.3 > docs/dev/11-opencode-v1.15-sync-audit.md
 ```
 
-- [ ] **Step 2: Verify the report contains the required sections**
+- [x] **Step 2: Verify the report contains the required sections**
 
 ```bash
 rg -n "Summary|Change Statuses|Changed Scopes|Backend Modules Changed|Railwise Mapping Coverage|Recommended Migration Order" docs/dev/11-opencode-v1.15-sync-audit.md
 ```
 
-- [ ] **Step 3: Commit the audit baseline**
+- [x] **Step 3: Commit the audit baseline**
 
 ```bash
 git add scripts/opencode-sync-audit.ts docs/dev/11-opencode-v1.15-sync-audit.md docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
@@ -45,17 +45,17 @@ git commit -m "chore(sync): add opencode v1.15 audit baseline"
 - Compare: `v1.15.3:packages/opencode/script/publish.ts`
 - Test: `packages/railwise/script/build.ts`
 
-- [ ] **Step 1: Inspect upstream script diffs**
+- [x] **Step 1: Inspect upstream script diffs**
 
 ```bash
 git diff v1.4.5..v1.15.3 -- packages/opencode/script/build.ts packages/opencode/script/publish.ts
 ```
 
-- [ ] **Step 2: Port only compatibility changes**
+- [x] **Step 2: Port only compatibility changes**
 
 Keep Railwise names, binary names, release repository, and `RAILWISE_*` defines. Port upstream fixes that affect target selection, package metadata, Bun compile options, or release artifact generation.
 
-- [ ] **Step 3: Verify single-platform build script still runs**
+- [x] **Step 3: Verify single-platform build script still runs**
 
 ```bash
 cd packages/railwise

--- a/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
+++ b/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
@@ -1,0 +1,231 @@
+# opencode v1.15.3 Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring Railwise-CLI forward toward opencode v1.15.3 without overwriting Railwise branding, domain agents, desktop sidecar, or installer work.
+
+**Architecture:** Railwise is a fork snapshot, not a normal ancestry-preserving fork: `HEAD` has no merge-base with upstream `v1.15.3`. Treat upstream as a source snapshot and port changes by subsystem, mapping `packages/opencode` to `packages/railwise` and preserving Railwise-only modules.
+
+**Tech Stack:** Bun, TypeScript, SolidJS app shell, Tauri desktop, git worktrees, upstream `sst/opencode` refs.
+
+---
+
+### Task 1: Sync Audit Baseline
+
+**Files:**
+- Create: `scripts/opencode-sync-audit.ts`
+- Create: `docs/dev/11-opencode-v1.15-sync-audit.md`
+- Modify: none
+
+- [ ] **Step 1: Run the audit script**
+
+```bash
+bun ./scripts/opencode-sync-audit.ts v1.4.5 v1.15.3 > docs/dev/11-opencode-v1.15-sync-audit.md
+```
+
+- [ ] **Step 2: Verify the report contains the required sections**
+
+```bash
+rg -n "Summary|Change Statuses|Changed Scopes|Backend Modules Changed|Railwise Mapping Coverage|Recommended Migration Order" docs/dev/11-opencode-v1.15-sync-audit.md
+```
+
+- [ ] **Step 3: Commit the audit baseline**
+
+```bash
+git add scripts/opencode-sync-audit.ts docs/dev/11-opencode-v1.15-sync-audit.md docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
+git commit -m "chore(sync): add opencode v1.15 audit baseline"
+```
+
+### Task 2: Build Script Compatibility Batch
+
+**Files:**
+- Modify: `packages/railwise/script/build.ts`
+- Modify: `packages/railwise/script/publish.ts`
+- Compare: `v1.15.3:packages/opencode/script/build.ts`
+- Compare: `v1.15.3:packages/opencode/script/publish.ts`
+- Test: `packages/railwise/script/build.ts`
+
+- [ ] **Step 1: Inspect upstream script diffs**
+
+```bash
+git diff v1.4.5..v1.15.3 -- packages/opencode/script/build.ts packages/opencode/script/publish.ts
+```
+
+- [ ] **Step 2: Port only compatibility changes**
+
+Keep Railwise names, binary names, release repository, and `RAILWISE_*` defines. Port upstream fixes that affect target selection, package metadata, Bun compile options, or release artifact generation.
+
+- [ ] **Step 3: Verify single-platform build script still runs**
+
+```bash
+cd packages/railwise
+bun run build --single --skip-install
+```
+
+Expected: `dist/railwise-darwin-arm64/bin/railwise` on Apple Silicon or matching local platform binary.
+
+### Task 3: Config And Schema Batch
+
+**Files:**
+- Modify: `packages/railwise/src/config/config.ts`
+- Modify: `packages/railwise/src/config/tui-schema.ts`
+- Modify: `packages/railwise/src/permission/*.ts`
+- Compare: `v1.15.3:packages/opencode/src/config`
+- Compare: `v1.15.3:packages/opencode/src/permission`
+- Test: `packages/railwise/test/config/config.test.ts`
+
+- [ ] **Step 1: List upstream config and permission changes**
+
+```bash
+git diff --name-status v1.4.5..v1.15.3 -- packages/opencode/src/config packages/opencode/src/permission
+```
+
+- [ ] **Step 2: Port parser compatibility fixes**
+
+Preserve Railwise config paths, `.railwise` directories, and Railwise defaults. Port upstream changes for tolerant config parsing, plugin schema compatibility, permission validation, and model selection schema drift.
+
+- [ ] **Step 3: Run focused tests**
+
+```bash
+cd packages/railwise
+bun test test/config/config.test.ts test/permission --timeout 30000
+```
+
+### Task 4: Server And Session Runtime Batch
+
+**Files:**
+- Modify: `packages/railwise/src/server/**`
+- Modify: `packages/railwise/src/session/**`
+- Modify: `packages/railwise/src/sync/**`
+- Compare: `v1.15.3:packages/opencode/src/server`
+- Compare: `v1.15.3:packages/opencode/src/session`
+- Compare: `v1.15.3:packages/opencode/src/sync`
+- Test: `packages/railwise/test/server/**`
+- Test: `packages/railwise/test/session/**`
+
+- [ ] **Step 1: List upstream runtime changes**
+
+```bash
+git diff --name-status v1.4.5..v1.15.3 -- packages/opencode/src/server packages/opencode/src/session packages/opencode/src/sync
+```
+
+- [ ] **Step 2: Port event and HTTP API fixes**
+
+Preserve Railwise route naming, control-plane extensions, industry agents, and desktop sidecar assumptions. Port upstream session event shape fixes, question lifecycle fixes, SSE stability fixes, and session status handling.
+
+- [ ] **Step 3: Run focused tests**
+
+```bash
+cd packages/railwise
+bun test test/server test/session --timeout 30000
+```
+
+### Task 5: Tool, Plugin, Provider Batch
+
+**Files:**
+- Modify: `packages/railwise/src/tool/**`
+- Modify: `packages/railwise/src/plugin/**`
+- Modify: `packages/railwise/src/provider/**`
+- Modify: `packages/railwise/src/mcp/**`
+- Compare: `v1.15.3:packages/opencode/src/tool`
+- Compare: `v1.15.3:packages/opencode/src/plugin`
+- Compare: `v1.15.3:packages/opencode/src/provider`
+- Compare: `v1.15.3:packages/opencode/src/mcp`
+- Test: `packages/railwise/test/tool/**`
+- Test: `packages/railwise/test/provider/**`
+
+- [ ] **Step 1: List upstream integration changes**
+
+```bash
+git diff --name-status v1.4.5..v1.15.3 -- packages/opencode/src/tool packages/opencode/src/plugin packages/opencode/src/provider packages/opencode/src/mcp
+```
+
+- [ ] **Step 2: Port compatibility fixes**
+
+Keep Railwise provider branding and domain tools. Port upstream fixes for MCP output schemas, provider request headers, plugin compatibility checks, and tool argument validation.
+
+- [ ] **Step 3: Run focused tests**
+
+```bash
+cd packages/railwise
+bun test test/tool test/provider test/plugin test/mcp --timeout 30000
+```
+
+### Task 6: Desktop App Shell Batch
+
+**Files:**
+- Modify: `packages/app/src/components/prompt-input/**`
+- Modify: `packages/app/src/context/global-sync/**`
+- Modify: `packages/app/src/utils/**`
+- Modify: `packages/app/src/pages/session/**`
+- Preserve: `packages/app/src/pages/agents/**`
+- Preserve: Railwise Chinese copy and domain workflows
+- Compare: `v1.15.3:packages/app/src`
+- Test: `packages/app`
+
+- [ ] **Step 1: List upstream app changes**
+
+```bash
+git diff --name-status v1.4.5..v1.15.3 -- packages/app/src
+```
+
+- [ ] **Step 2: Port targeted app fixes**
+
+Prioritize prompt input attachment handling, terminal websocket URL generation, global sync queue/session cache fixes, settings provider fixes, and session timeline stability. Do not delete Railwise multi-agent pages or domain workflow UI.
+
+- [ ] **Step 3: Run app typecheck**
+
+```bash
+cd packages/app
+bun run typecheck
+```
+
+### Task 7: SDK Regeneration And Verification
+
+**Files:**
+- Modify: `packages/sdk/js/**`
+- Modify: generated API types as needed
+- Test: `packages/railwise`
+- Test: `packages/desktop`
+
+- [ ] **Step 1: Regenerate JavaScript SDK**
+
+```bash
+./packages/sdk/js/script/build.ts
+```
+
+- [ ] **Step 2: Run package typechecks**
+
+```bash
+cd packages/railwise
+bun run typecheck
+cd ../desktop
+bun run typecheck
+```
+
+- [ ] **Step 3: Verify Windows internal installer workflow guard**
+
+```bash
+bun ./scripts/verify-desktop-windows-internal.ts
+```
+
+### Task 8: Release Candidate Installer Check
+
+**Files:**
+- Modify: none unless verification exposes packaging issues
+- Test: GitHub Actions `Desktop Release`
+
+- [ ] **Step 1: Trigger unsigned Windows internal build**
+
+```bash
+gh workflow run desktop-release.yml --repo railwise-cn/RAILWISE-CLI -f version=1.3.0-internal.sync -f windows_unsigned_internal=true
+```
+
+- [ ] **Step 2: Download artifact and verify installer**
+
+```bash
+gh run download <run-id> --repo railwise-cn/RAILWISE-CLI --dir ~/Desktop/railwise-windows-sync-test
+find ~/Desktop/railwise-windows-sync-test -type f -iname "*.exe" -exec file {} \;
+```
+
+Expected: Windows PE NSIS installer.

--- a/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
+++ b/docs/superpowers/plans/2026-05-17-opencode-v1.15-sync.md
@@ -148,7 +148,12 @@ git diff --name-status v1.4.5..v1.15.3 -- packages/opencode/src/tool packages/op
 
 Keep Railwise provider branding and domain tools. Port upstream fixes for MCP output schemas, provider request headers, plugin compatibility checks, and tool argument validation.
 
-Scoped progress: MCP output schema compatibility has been ported. Railwise now preserves MCP tools when an external server returns an invalid or unresolvable `outputSchema`, matching the safe fallback added upstream in opencode v1.15.3. Provider, plugin, and tool validation changes remain in this batch.
+Scoped progress:
+
+- MCP output schema compatibility has been ported. Railwise now preserves MCP tools when an external server returns an invalid or unresolvable `outputSchema`, matching the safe fallback added upstream in opencode v1.15.3.
+- Plugin SDK client authentication headers have been ported. Railwise now reuses server Basic Auth headers for in-process plugin SDK calls when `RAILWISE_SERVER_PASSWORD` is configured.
+
+Provider and tool validation changes remain in this batch.
 
 - [x] **Step 3a: Run focused MCP tests**
 

--- a/packages/app/src/components/prompt-input/build-request-parts.test.ts
+++ b/packages/app/src/components/prompt-input/build-request-parts.test.ts
@@ -65,6 +65,47 @@ describe("buildRequestParts", () => {
     expect(synthetic).toHaveLength(1)
   })
 
+  test("adds metadata and mentioned files for commented context", () => {
+    const result = buildRequestParts({
+      prompt: [],
+      context: [
+        {
+          key: "ctx:comment",
+          type: "file",
+          path: "src/foo.ts",
+          selection: { startLine: 7, startChar: 0, endLine: 9, endChar: 5 },
+          comment: "compare this with @src/bar.ts.",
+          commentOrigin: "review",
+          preview: "const value = 1",
+        },
+      ],
+      images: [],
+      text: "please review",
+      messageID: "msg_comment",
+      sessionID: "ses_comment",
+      sessionDirectory: "/repo",
+    })
+
+    const note = result.requestParts.find((part) => part.type === "text" && part.synthetic)
+    const files = result.requestParts.filter((part) => part.type === "file")
+
+    expect(note?.type).toBe("text")
+    if (!note || note.type !== "text") throw new Error("missing comment note")
+    expect(note?.text).toContain("# src/foo.ts")
+    expect(note?.metadata).toEqual({
+      type: "comment",
+      path: "src/foo.ts",
+      selection: { startLine: 7, startChar: 0, endLine: 9, endChar: 5 },
+      comment: "compare this with @src/bar.ts.",
+      preview: "const value = 1",
+      origin: "review",
+    })
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo/src/foo.ts?start=7&end=9")).toBe(
+      true,
+    )
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo/src/bar.ts")).toBe(true)
+  })
+
   test("handles Windows paths correctly (simulated on macOS)", () => {
     const prompt: Prompt = [{ type: "file", path: "src\\foo.ts", content: "@src\\foo.ts", start: 0, end: 11 }]
 

--- a/packages/app/src/components/prompt-input/build-request-parts.ts
+++ b/packages/app/src/components/prompt-input/build-request-parts.ts
@@ -3,6 +3,7 @@ import { type AgentPartInput, type FilePartInput, type Part, type TextPartInput 
 import type { FileSelection } from "@/context/file"
 import { encodeFilePath } from "@/context/file/path"
 import type { AgentPart, FileAttachmentPart, ImageAttachmentPart, Prompt } from "@/context/prompt"
+import { createCommentMetadata, formatCommentNote } from "@/utils/comment-note"
 import { Identifier } from "@/utils/id"
 
 type PromptRequestPart = (TextPartInput | FilePartInput | AgentPartInput) & { id: string }
@@ -38,20 +39,18 @@ const absolute = (directory: string, path: string) => {
 const fileQuery = (selection: FileSelection | undefined) =>
   selection ? `?start=${selection.startLine}&end=${selection.endLine}` : ""
 
+const mention = /(^|[\s([{"'])@(\S+)/g
+
+const parseCommentMentions = (comment: string) => {
+  return Array.from(comment.matchAll(mention)).flatMap((match) => {
+    const path = (match[2] ?? "").replace(/[.,!?;:)}\]"']+$/, "")
+    if (!path) return []
+    return [path]
+  })
+}
+
 const isFileAttachment = (part: Prompt[number]): part is FileAttachmentPart => part.type === "file"
 const isAgentAttachment = (part: Prompt[number]): part is AgentPart => part.type === "agent"
-
-const commentNote = (path: string, selection: FileSelection | undefined, comment: string) => {
-  const start = selection ? Math.min(selection.startLine, selection.endLine) : undefined
-  const end = selection ? Math.max(selection.startLine, selection.endLine) : undefined
-  const range =
-    start === undefined || end === undefined
-      ? "this file"
-      : start === end
-        ? `line ${start}`
-        : `lines ${start} through ${end}`
-  return `The user made the following comment regarding ${range} of ${path}: ${comment}`
-}
 
 const toOptimisticPart = (part: PromptRequestPart, sessionID: string, messageID: string): Part => {
   if (part.type === "text") {
@@ -149,14 +148,37 @@ export function buildRequestParts(input: BuildRequestPartsInput) {
 
     if (!comment) return [filePart]
 
+    const mentions = parseCommentMentions(comment).flatMap((path) => {
+      const url = `file://${encodeFilePath(absolute(input.sessionDirectory, path))}`
+      if (used.has(url)) return []
+      used.add(url)
+      return [
+        {
+          id: Identifier.ascending("part"),
+          type: "file",
+          mime: "text/plain",
+          url,
+          filename: getFilename(path),
+        } satisfies PromptRequestPart,
+      ]
+    })
+
     return [
       {
         id: Identifier.ascending("part"),
         type: "text",
-        text: commentNote(item.path, item.selection, comment),
+        text: formatCommentNote({ path: item.path, selection: item.selection, comment }),
         synthetic: true,
+        metadata: createCommentMetadata({
+          path: item.path,
+          selection: item.selection,
+          comment,
+          preview: item.preview,
+          origin: item.commentOrigin,
+        }),
       } satisfies PromptRequestPart,
       filePart,
+      ...mentions,
     ]
   })
 

--- a/packages/app/src/components/prompt-input/placeholder.test.ts
+++ b/packages/app/src/components/prompt-input/placeholder.test.ts
@@ -12,7 +12,7 @@ describe("promptPlaceholder", () => {
       suggest: true,
       t,
     })
-    expect(value).toBe("prompt.placeholder.shell")
+    expect(value).toBe("prompt.placeholder.shell:example")
   })
 
   test("returns summarize placeholders for comment context", () => {

--- a/packages/app/src/components/prompt-input/placeholder.ts
+++ b/packages/app/src/components/prompt-input/placeholder.ts
@@ -7,7 +7,7 @@ type PromptPlaceholderInput = {
 }
 
 export function promptPlaceholder(input: PromptPlaceholderInput) {
-  if (input.mode === "shell") return input.t("prompt.placeholder.shell")
+  if (input.mode === "shell") return input.t("prompt.placeholder.shell", { example: input.example })
   if (input.commentCount > 1) return input.t("prompt.placeholder.summarizeComments")
   if (input.commentCount === 1) return input.t("prompt.placeholder.summarizeComment")
   if (!input.suggest) return input.t("prompt.placeholder.simple")

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -2,7 +2,7 @@ import type { Message } from "@railwise/sdk/v2/client"
 import { showToast } from "@railwise/ui/toast"
 import { base64Encode } from "@railwise/util/encode"
 import { useNavigate, useParams } from "@solidjs/router"
-import type { Accessor } from "solid-js"
+import { batch, type Accessor } from "solid-js"
 import type { FileSelection } from "@/context/file"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
@@ -121,7 +121,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     const mode = input.mode()
 
     if (text.trim().length === 0 && images.length === 0 && input.commentCount() === 0) {
-      if (input.working()) abort()
+      if (input.working()) void abort()
       return
     }
 
@@ -327,9 +327,11 @@ export function createPromptSubmit(input: PromptSubmitInput) {
         messageID,
       })
 
-    removeCommentItems(commentItems)
-    clearInput()
-    addOptimisticMessage()
+    batch(() => {
+      removeCommentItems(commentItems)
+      clearInput()
+      addOptimisticMessage()
+    })
 
     const waitForWorktree = async () => {
       const worktree = WorktreeState.get(sessionDirectory)
@@ -341,12 +343,14 @@ export function createPromptSubmit(input: PromptSubmitInput) {
 
       const controller = new AbortController()
       const cleanup = () => {
-        if (sessionDirectory === projectDirectory) {
-          sync.set("session_status", session.id, { type: "idle" })
-        }
-        removeOptimisticMessage()
-        restoreCommentItems(commentItems)
-        restoreInput()
+        batch(() => {
+          if (sessionDirectory === projectDirectory) {
+            sync.set("session_status", session.id, { type: "idle" })
+          }
+          removeOptimisticMessage()
+          restoreCommentItems(commentItems)
+          restoreInput()
+        })
       }
 
       pending.set(session.id, { abort: controller, cleanup })
@@ -401,16 +405,18 @@ export function createPromptSubmit(input: PromptSubmitInput) {
 
     void send().catch((err) => {
       pending.delete(session.id)
-      if (sessionDirectory === projectDirectory) {
-        sync.set("session_status", session.id, { type: "idle" })
-      }
       showToast({
         title: language.t("prompt.toast.promptSendFailed.title"),
         description: errorMessage(err),
       })
-      removeOptimisticMessage()
-      restoreCommentItems(commentItems)
-      restoreInput()
+      batch(() => {
+        if (sessionDirectory === projectDirectory) {
+          sync.set("session_status", session.id, { type: "idle" })
+        }
+        removeOptimisticMessage()
+        restoreCommentItems(commentItems)
+        restoreInput()
+      })
     })
   }
 

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -12,6 +12,7 @@ import { monoFontFamily, useSettings } from "@/context/settings"
 import type { LocalPTY } from "@/context/terminal"
 import { disposeIfDisposable, getHoveredLinkText, setOptionIfSupported } from "@/utils/runtime-adapters"
 import { terminalWriter } from "@/utils/terminal-writer"
+import { terminalWebSocketURL } from "@/utils/terminal-websocket-url"
 
 const TOGGLE_TERMINAL_ID = "terminal.toggle"
 const DEFAULT_TOGGLE_TERMINAL_KEYBIND = "ctrl+`"
@@ -156,6 +157,10 @@ export const Terminal = (props: TerminalProps) => {
   const theme = useTheme()
   const language = useLanguage()
   const server = useServer()
+  const directory = sdk.directory
+  const url = sdk.url
+  const auth = server.current?.http
+  const sameOrigin = new URL(url, location.href).origin === location.origin
   let container!: HTMLDivElement
   const [local, others] = splitProps(props, ["pty", "class", "classList", "onConnect", "onConnectError"])
   let ws: WebSocket | undefined
@@ -447,14 +452,18 @@ export const Terminal = (props: TerminalProps) => {
       const once = { value: false }
       let closing = false
 
-      const url = new URL(sdk.url + `/pty/${local.pty.id}/connect`)
-      url.searchParams.set("directory", sdk.directory)
-      url.searchParams.set("cursor", String(start !== undefined ? start : local.pty.buffer ? -1 : 0))
-      url.protocol = url.protocol === "https:" ? "wss:" : "ws:"
-      url.username = server.current?.http.username ?? ""
-      url.password = server.current?.http.password ?? ""
+      const socketUrl = terminalWebSocketURL({
+        url,
+        id: local.pty.id,
+        directory,
+        cursor: start !== undefined ? start : local.pty.buffer ? -1 : 0,
+        sameOrigin,
+        username: auth?.username,
+        password: auth?.password,
+        authToken: !!auth?.password,
+      })
 
-      const socket = new WebSocket(url)
+      const socket = new WebSocket(socketUrl)
       socket.binaryType = "arraybuffer"
       ws = socket
 

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -34,7 +34,7 @@ import { estimateRootSessionTotal, loadRootSessionsWithFallback } from "./global
 import { trimSessions } from "./global-sync/session-trim"
 import type { ProjectMeta } from "./global-sync/types"
 import { SESSION_RECENT_LIMIT } from "./global-sync/types"
-import { sanitizeProject } from "./global-sync/utils"
+import { directoryKey, sanitizeProject } from "./global-sync/utils"
 import { usePlatform } from "./platform"
 
 type GlobalStore = {
@@ -103,6 +103,7 @@ function createGlobalSync() {
 
   const queue = createRefreshQueue({
     paused,
+    key: directoryKey,
     bootstrap,
     bootstrapInstance,
   })

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -15,7 +15,7 @@ import { retry } from "@railwise/util/retry"
 import { batch } from "solid-js"
 import { reconcile, type SetStoreFunction, type Store } from "solid-js/store"
 import type { State, VcsCache } from "./types"
-import { cmp, normalizeProviderList } from "./utils"
+import { cmp, normalizeAgentList, normalizeProviderList } from "./utils"
 
 type GlobalStore = {
   ready: boolean
@@ -124,7 +124,7 @@ export async function bootstrapDirectory(input: {
       input.sdk.provider.list().then((x) => {
         input.setStore("provider", normalizeProviderList(x.data!))
       }),
-    agent: () => input.sdk.app.agents().then((x) => input.setStore("agent", x.data ?? [])),
+    agent: () => input.sdk.app.agents().then((x) => input.setStore("agent", normalizeAgentList(x.data))),
     config: () => input.sdk.config.get().then((x) => input.setStore("config", x.data!)),
   }
 

--- a/packages/app/src/context/global-sync/queue.test.ts
+++ b/packages/app/src/context/global-sync/queue.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test"
+import { createRefreshQueue } from "./queue"
+import { directoryKey } from "./utils"
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 10))
+
+describe("createRefreshQueue", () => {
+  test("clears queued directories by normalized key", async () => {
+    const calls: string[] = []
+    const queue = createRefreshQueue({
+      paused: () => false,
+      key: directoryKey,
+      bootstrap: async () => {},
+      bootstrapInstance: (directory) => {
+        calls.push(directory)
+      },
+    })
+
+    queue.push("C:\\tmp\\demo")
+    queue.clear("C:/tmp/demo")
+
+    await tick()
+
+    expect(calls).toEqual([])
+    queue.dispose()
+  })
+
+  test("passes the original directory to bootstrapInstance", async () => {
+    const calls: string[] = []
+    const queue = createRefreshQueue({
+      paused: () => false,
+      key: directoryKey,
+      bootstrap: async () => {},
+      bootstrapInstance: (directory) => {
+        calls.push(directory)
+      },
+    })
+
+    queue.push("C:\\tmp\\demo")
+
+    await tick()
+
+    expect(calls).toEqual(["C:\\tmp\\demo"])
+    queue.dispose()
+  })
+})

--- a/packages/app/src/context/global-sync/queue.ts
+++ b/packages/app/src/context/global-sync/queue.ts
@@ -2,22 +2,25 @@ type QueueInput = {
   paused: () => boolean
   bootstrap: () => Promise<void>
   bootstrapInstance: (directory: string) => Promise<void> | void
+  key?: (directory: string) => string
 }
 
 export function createRefreshQueue(input: QueueInput) {
-  const queued = new Set<string>()
+  const queued = new Map<string, string>()
   let root = false
   let running = false
   let timer: ReturnType<typeof setTimeout> | undefined
+
+  const key = input.key ?? ((directory: string) => directory)
 
   const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
 
   const take = (count: number) => {
     if (queued.size === 0) return [] as string[]
     const items: string[] = []
-    for (const item of queued) {
-      queued.delete(item)
-      items.push(item)
+    for (const [id, directory] of queued) {
+      queued.delete(id)
+      items.push(directory)
       if (items.length >= count) break
     }
     return items
@@ -33,7 +36,7 @@ export function createRefreshQueue(input: QueueInput) {
 
   const push = (directory: string) => {
     if (!directory) return
-    queued.add(directory)
+    queued.set(key(directory), directory)
     if (input.paused()) return
     schedule()
   }
@@ -72,7 +75,7 @@ export function createRefreshQueue(input: QueueInput) {
     push,
     refresh,
     clear(directory: string) {
-      queued.delete(directory)
+      queued.delete(key(directory))
     },
     dispose() {
       if (!timer) return

--- a/packages/app/src/context/global-sync/utils.test.ts
+++ b/packages/app/src/context/global-sync/utils.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+import type { Agent } from "@railwise/sdk/v2/client"
+import { directoryKey, normalizeAgentList } from "./utils"
+
+const agent = (name = "build") =>
+  ({
+    name,
+    mode: "primary",
+    permission: {},
+    options: {},
+  }) as Agent
+
+describe("normalizeAgentList", () => {
+  test("keeps array payloads", () => {
+    expect(normalizeAgentList([agent("build"), agent("docs")])).toEqual([agent("build"), agent("docs")])
+  })
+
+  test("wraps a single agent payload", () => {
+    expect(normalizeAgentList(agent("docs"))).toEqual([agent("docs")])
+  })
+
+  test("extracts agents from keyed objects", () => {
+    expect(
+      normalizeAgentList({
+        build: agent("build"),
+        docs: agent("docs"),
+      }),
+    ).toEqual([agent("build"), agent("docs")])
+  })
+
+  test("drops invalid payloads", () => {
+    expect(normalizeAgentList({ name: "AbortError" })).toEqual([])
+    expect(normalizeAgentList([{ name: "build" }, agent("docs")])).toEqual([agent("docs")])
+  })
+})
+
+describe("directoryKey", () => {
+  test("normalizes slashes", () => {
+    expect(String(directoryKey("C:\\Repos\\railwise"))).toBe("C:/Repos/railwise")
+    expect(String(directoryKey("C:/Repos/railwise"))).toBe("C:/Repos/railwise")
+  })
+
+  test("preserves backslashes in posix paths", () => {
+    expect(String(directoryKey("/tmp/foo\\bar"))).toBe("/tmp/foo\\bar")
+  })
+
+  test("trims trailing slashes without breaking roots", () => {
+    expect(String(directoryKey("C:/Repos/railwise/"))).toBe("C:/Repos/railwise")
+    expect(String(directoryKey("C:/"))).toBe("C:/")
+    expect(String(directoryKey("/"))).toBe("/")
+  })
+})

--- a/packages/app/src/context/global-sync/utils.ts
+++ b/packages/app/src/context/global-sync/utils.ts
@@ -1,6 +1,21 @@
-import type { Project, ProviderListResponse } from "@railwise/sdk/v2/client"
+import type { Agent, Project, ProviderListResponse } from "@railwise/sdk/v2/client"
+export { pathKey as directoryKey, type PathKey as DirectoryKey } from "@/utils/path-key"
 
 export const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
+
+function isAgent(input: unknown): input is Agent {
+  if (!input || typeof input !== "object") return false
+  const item = input as { name?: unknown; mode?: unknown }
+  if (typeof item.name !== "string") return false
+  return item.mode === "subagent" || item.mode === "primary" || item.mode === "all"
+}
+
+export function normalizeAgentList(input: unknown): Agent[] {
+  if (Array.isArray(input)) return input.filter(isAgent)
+  if (isAgent(input)) return [input]
+  if (!input || typeof input !== "object") return []
+  return Object.values(input).filter(isAgent)
+}
 
 export function normalizeProviderList(input: ProviderListResponse): ProviderListResponse {
   return {

--- a/packages/app/src/utils/path-key.ts
+++ b/packages/app/src/utils/path-key.ts
@@ -1,0 +1,24 @@
+export type PathKey = string & { _brand: "PathKey" }
+
+const isDrive = (value: string) => {
+  if (value.length !== 2) return false
+  const code = value.charCodeAt(0)
+  return value[1] === ":" && ((code >= 65 && code <= 90) || (code >= 97 && code <= 122))
+}
+
+const trimTrailingSlashes = (value: string) => {
+  for (let i = value.length - 1; i >= 0; i--) {
+    if (value[i] !== "/") return value.slice(0, i + 1)
+  }
+  return ""
+}
+
+const isWindowsPath = (value: string) => value[1] === ":" || value.startsWith("\\\\")
+
+export const pathKey = (path: string) => {
+  const value = isWindowsPath(path) ? path.replaceAll("\\", "/") : path
+  const trimmed = trimTrailingSlashes(value)
+  if (!trimmed && value.startsWith("/")) return "/" as PathKey
+  if (isDrive(trimmed)) return `${trimmed}/` as PathKey
+  return trimmed as PathKey
+}

--- a/packages/app/src/utils/server.test.ts
+++ b/packages/app/src/utils/server.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { authFromToken, authTokenFromCredentials } from "./server"
+
+describe("authFromToken", () => {
+  test("decodes basic auth credentials from auth_token", () => {
+    expect(authFromToken(btoa("kit:secret"))).toEqual({ username: "kit", password: "secret" })
+  })
+
+  test("defaults blank username to railwise", () => {
+    expect(authFromToken(btoa(":secret"))).toEqual({ username: "railwise", password: "secret" })
+  })
+
+  test("ignores malformed tokens", () => {
+    expect(authFromToken("not base64")).toBeUndefined()
+    expect(authFromToken(btoa("missing-separator"))).toBeUndefined()
+  })
+})
+
+describe("authTokenFromCredentials", () => {
+  test("encodes credentials with the default username", () => {
+    expect(authTokenFromCredentials({ password: "secret" })).toBe(btoa("railwise:secret"))
+  })
+})

--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -1,5 +1,21 @@
 import { createRailwiseClient } from "@railwise/sdk/v2/client"
 import type { ServerConnection } from "@/context/server"
+import { decode64 } from "@/utils/base64"
+
+export function authTokenFromCredentials(input: { username?: string; password: string }) {
+  return btoa(`${input.username ?? "railwise"}:${input.password}`)
+}
+
+export function authFromToken(token: string | null) {
+  const decoded = decode64(token ?? undefined)
+  if (!decoded) return
+  const separator = decoded.indexOf(":")
+  if (separator === -1) return
+  return {
+    username: decoded.slice(0, separator) || "railwise",
+    password: decoded.slice(separator + 1),
+  }
+}
 
 export function createSdkForServer({
   server,
@@ -16,7 +32,10 @@ export function createSdkForServer({
 
   return createRailwiseClient({
     ...config,
-    headers: { ...config.headers, ...auth },
+    headers: {
+      ...(config.headers instanceof Headers ? Object.fromEntries(config.headers.entries()) : config.headers),
+      ...auth,
+    },
     baseUrl: server.url,
   })
 }

--- a/packages/app/src/utils/terminal-websocket-url.test.ts
+++ b/packages/app/src/utils/terminal-websocket-url.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+import { terminalWebSocketURL } from "./terminal-websocket-url"
+
+describe("terminalWebSocketURL", () => {
+  test("uses query auth without embedding credentials in websocket URL", () => {
+    const url = terminalWebSocketURL({
+      url: "http://127.0.0.1:49365",
+      id: "pty_test",
+      directory: "/tmp/project",
+      cursor: 0,
+      sameOrigin: false,
+      username: "railwise",
+      password: "secret",
+    })
+
+    expect(url.protocol).toBe("ws:")
+    expect(url.username).toBe("")
+    expect(url.password).toBe("")
+    expect(url.searchParams.get("auth_token")).toBe(btoa("railwise:secret"))
+  })
+
+  test("omits query auth for same-origin saved credentials", () => {
+    const url = terminalWebSocketURL({
+      url: "https://app.example.test",
+      id: "pty_test",
+      directory: "/tmp/project",
+      cursor: 10,
+      sameOrigin: true,
+      username: "railwise",
+      password: "secret",
+    })
+
+    expect(url.protocol).toBe("wss:")
+    expect(url.searchParams.has("auth_token")).toBe(false)
+  })
+
+  test("uses query auth for same-origin credentials from auth_token", () => {
+    const url = terminalWebSocketURL({
+      url: "https://app.example.test",
+      id: "pty_test",
+      directory: "/tmp/project",
+      cursor: 10,
+      sameOrigin: true,
+      username: "railwise",
+      password: "secret",
+      authToken: true,
+    })
+
+    expect(url.protocol).toBe("wss:")
+    expect(url.searchParams.get("auth_token")).toBe(btoa("railwise:secret"))
+  })
+})

--- a/packages/app/src/utils/terminal-websocket-url.ts
+++ b/packages/app/src/utils/terminal-websocket-url.ts
@@ -1,0 +1,28 @@
+import { authTokenFromCredentials } from "@/utils/server"
+
+export function terminalWebSocketURL(input: {
+  url: string
+  id: string
+  directory: string
+  cursor: number
+  ticket?: string
+  sameOrigin?: boolean
+  username?: string
+  password?: string
+  authToken?: boolean
+}) {
+  const next = new URL(`${input.url}/pty/${input.id}/connect`)
+  next.searchParams.set("directory", input.directory)
+  next.searchParams.set("cursor", String(input.cursor))
+  next.protocol = next.protocol === "https:" ? "wss:" : "ws:"
+  if (input.ticket) {
+    next.searchParams.set("ticket", input.ticket)
+    return next
+  }
+  if (input.password && (!input.sameOrigin || input.authToken))
+    next.searchParams.set(
+      "auth_token",
+      authTokenFromCredentials({ username: input.username, password: input.password }),
+    )
+  return next
+}

--- a/packages/railwise/script/build.ts
+++ b/packages/railwise/script/build.ts
@@ -54,6 +54,7 @@ console.log(`Loaded ${migrations.length} migrations`)
 const singleFlag = process.argv.includes("--single")
 const baselineFlag = process.argv.includes("--baseline")
 const skipInstall = process.argv.includes("--skip-install")
+const sourcemapsFlag = process.argv.includes("--sourcemaps")
 
 const allTargets: {
   os: string
@@ -156,22 +157,27 @@ for (const item of targets) {
   console.log(`building ${name}`)
   await $`mkdir -p dist/${name}/bin`
 
-  const parserWorker = fs.realpathSync(path.resolve(dir, "./node_modules/@opentui/core/parser.worker.js"))
+  const localPath = path.resolve(dir, "node_modules/@opentui/core/parser.worker.js")
+  const rootPath = path.resolve(dir, "../../node_modules/@opentui/core/parser.worker.js")
+  const parserWorker = fs.realpathSync(fs.existsSync(localPath) ? localPath : rootPath)
   const workerPath = "./src/cli/cmd/tui/worker.ts"
 
   // Use platform-specific bunfs root path based on target OS
   const bunfsRoot = item.os === "win32" ? "B:/~BUN/root/" : "/$bunfs/root/"
   const workerRelativePath = path.relative(dir, parserWorker).replaceAll("\\", "/")
 
-  await Bun.build({
+  const config = {
     conditions: ["browser"],
     tsconfig: "./tsconfig.json",
     plugins: [solidPlugin],
-    sourcemap: "external",
+    external: ["node-gyp"],
+    format: "esm" as const,
+    minify: true,
+    sourcemap: sourcemapsFlag ? ("linked" as const) : ("none" as const),
+    splitting: true,
     compile: {
       autoloadBunfig: false,
       autoloadDotenv: false,
-      //@ts-ignore (bun types aren't up to date)
       autoloadTsconfig: true,
       autoloadPackageJson: true,
       target: name.replace(pkg.name, "bun") as any,
@@ -188,7 +194,17 @@ for (const item of targets) {
       RAILWISE_CHANNEL: `'${Script.channel}'`,
       RAILWISE_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",
     },
-  })
+  }
+  await Bun.build(config)
+
+  if (item.os === process.platform && item.arch === process.arch && !item.abi) {
+    const result = await $`dist/${name}/bin/railwise --version`.quiet().throws(false)
+    if (result.exitCode !== 0) {
+      console.error(`Smoke test failed for ${name}: ${result.stderr.toString("utf8")}`)
+      process.exit(1)
+    }
+    console.log(`Smoke test passed: ${result.stdout.toString("utf8").trim()}`)
+  }
 
   await $`rm -rf ./dist/${name}/bin/tui`
   await Bun.file(`dist/${name}/package.json`).write(
@@ -196,6 +212,7 @@ for (const item of targets) {
       {
         name,
         version: Script.version,
+        preferUnplugged: true,
         os: [item.os],
         cpu: [item.arch],
       },

--- a/packages/railwise/src/config/config.ts
+++ b/packages/railwise/src/config/config.ts
@@ -627,6 +627,28 @@ export namespace Config {
     return result
   }
 
+  const legacyTools = z.preprocess((val) => {
+    if (!isRecord(val)) return val
+    const result: Record<string, boolean> = {}
+    for (const [tool, enabled] of Object.entries(val)) {
+      if (typeof enabled === "boolean") {
+        result[tool] = enabled
+        continue
+      }
+      if (!Array.isArray(enabled)) continue
+      for (const item of enabled) {
+        if (typeof item === "string") result[item] = true
+      }
+    }
+    return result
+  }, z.record(z.string(), z.boolean()))
+
+  function normalizeLoadedConfig(data: unknown) {
+    if (!isRecord(data)) return data
+    const { version, system, ...rest } = data
+    return rest
+  }
+
   export const Permission = z
     .preprocess(
       permissionPreprocess,
@@ -688,7 +710,7 @@ export namespace Config {
       temperature: z.number().optional(),
       top_p: z.number().optional(),
       prompt: z.string().optional(),
-      tools: z.record(z.string(), z.boolean()).optional().describe("@deprecated Use 'permission' field instead"),
+      tools: legacyTools.optional().describe("@deprecated Use 'permission' field instead"),
       disable: z.boolean().optional(),
       description: z.string().optional().describe("Description of when to use the agent"),
       mode: z.enum(["subagent", "primary", "all"]).optional(),
@@ -1160,7 +1182,7 @@ export namespace Config {
       instructions: z.array(z.string()).optional().describe("Additional instruction files or patterns to include"),
       layout: Layout.optional().describe("@deprecated Always uses stretch layout."),
       permission: Permission.optional(),
-      tools: z.record(z.string(), z.boolean()).optional(),
+      tools: legacyTools.optional(),
       enterprise: z
         .object({
           url: z.string().optional().describe("Enterprise URL"),
@@ -1331,7 +1353,7 @@ export namespace Config {
       })
     }
 
-    const parsed = Info.safeParse(data)
+    const parsed = Info.safeParse(normalizeLoadedConfig(data))
     if (parsed.success) {
       if (!parsed.data.$schema && isFile) {
         parsed.data.$schema = "https://railwise.ai/config.json"

--- a/packages/railwise/src/global/index.ts
+++ b/packages/railwise/src/global/index.ts
@@ -15,7 +15,7 @@ export namespace Global {
   export const Path = {
     // Allow override via RAILWISE_HOME for embedded clients and RAILWISE_TEST_HOME for tests.
     get home() {
-      return process.env.RAILWISE_HOME || process.env.RAILWISE_TEST_HOME || os.homedir()
+      return process.env.RAILWISE_TEST_HOME || process.env.RAILWISE_HOME || os.homedir()
     },
     data,
     bin: path.join(data, "bin"),

--- a/packages/railwise/src/mcp/index.ts
+++ b/packages/railwise/src/mcp/index.ts
@@ -6,7 +6,9 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import {
   CallToolResultSchema,
+  ListToolsResultSchema,
   type Tool as MCPToolDef,
+  ToolSchema,
   ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js"
 import { Config } from "../config/config"
@@ -27,6 +29,9 @@ import open from "open"
 export namespace MCP {
   const log = Log.create({ service: "mcp" })
   const DEFAULT_TIMEOUT = 30_000
+  const TolerantListToolsResultSchema = ListToolsResultSchema.extend({
+    tools: ToolSchema.omit({ outputSchema: true }).array(),
+  })
 
   export const Resource = z
     .object({
@@ -114,6 +119,46 @@ export namespace MCP {
       log.info("tools list changed notification received", { server: serverName })
       Bus.publish(ToolsChanged, { server: serverName })
     })
+  }
+
+  function isOutputSchemaValidationError(error: Error) {
+    return /can't resolve reference|resolves to more than one schema|outputSchema|schema.*reference|reference.*schema/i.test(
+      error.message,
+    )
+  }
+
+  async function listTools(key: string, client: MCPClient, timeout: number) {
+    const result = await withTimeout(client.listTools(), timeout).catch(async (err) => {
+      const error = err instanceof Error ? err : new Error(String(err))
+      if (!isOutputSchemaValidationError(error)) throw error
+
+      log.warn("failed to validate MCP tool output schemas, retrying without output schema validation", {
+        key,
+        error,
+      })
+
+      const result = await withTimeout(
+        client.request(
+          { method: "tools/list" },
+          TolerantListToolsResultSchema,
+          {
+            timeout,
+          },
+        ),
+        timeout,
+      )
+
+      return {
+        ...result,
+        tools: result.tools.map((tool) => ({
+          name: tool.name,
+          description: tool.description,
+          inputSchema: tool.inputSchema,
+        })) as MCPToolDef[],
+      }
+    })
+
+    return result.tools
   }
 
   // Convert MCP tool definition to AI SDK Tool type
@@ -463,7 +508,7 @@ export namespace MCP {
       }
     }
 
-    const result = await withTimeout(mcpClient.listTools(), mcp.timeout ?? DEFAULT_TIMEOUT).catch((err) => {
+    const result = await listTools(key, mcpClient, mcp.timeout ?? DEFAULT_TIMEOUT).catch((err) => {
       log.error("failed to get tools from client", { key, error: err })
       return undefined
     })
@@ -486,7 +531,7 @@ export namespace MCP {
       }
     }
 
-    log.info("create() successfully created client", { key, toolCount: result.tools.length })
+    log.info("create() successfully created client", { key, toolCount: result.length })
     return {
       mcpClient,
       status,
@@ -577,7 +622,10 @@ export namespace MCP {
 
     const toolsResults = await Promise.all(
       connectedClients.map(async ([clientName, client]) => {
-        const toolsResult = await client.listTools().catch((e) => {
+        const mcpConfig = config[clientName]
+        const entry = isMcpConfigured(mcpConfig) ? mcpConfig : undefined
+        const timeout = entry?.timeout ?? defaultTimeout ?? DEFAULT_TIMEOUT
+        const toolsResult = await listTools(clientName, client, timeout).catch((e) => {
           log.error("failed to get tools", { clientName, error: e.message })
           const failedStatus = {
             status: "failed" as const,
@@ -587,16 +635,13 @@ export namespace MCP {
           delete s.clients[clientName]
           return undefined
         })
-        return { clientName, client, toolsResult }
+        return { clientName, client, toolsResult, timeout }
       }),
     )
 
-    for (const { clientName, client, toolsResult } of toolsResults) {
+    for (const { clientName, client, toolsResult, timeout } of toolsResults) {
       if (!toolsResult) continue
-      const mcpConfig = config[clientName]
-      const entry = isMcpConfigured(mcpConfig) ? mcpConfig : undefined
-      const timeout = entry?.timeout ?? defaultTimeout
-      for (const mcpTool of toolsResult.tools) {
+      for (const mcpTool of toolsResult) {
         const sanitizedClientName = clientName.replace(/[^a-zA-Z0-9_-]/g, "_")
         const sanitizedToolName = mcpTool.name.replace(/[^a-zA-Z0-9_-]/g, "_")
         result[sanitizedClientName + "_" + sanitizedToolName] = await convertMcpTool(mcpTool, client, timeout)

--- a/packages/railwise/src/plugin/index.ts
+++ b/packages/railwise/src/plugin/index.ts
@@ -11,6 +11,7 @@ import { CodexAuthPlugin } from "./codex"
 import { Session } from "../session"
 import { NamedError } from "@railwise/util/error"
 import { CopilotAuthPlugin } from "./copilot"
+import { ServerAuth } from "@/server/auth"
 
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
@@ -21,6 +22,7 @@ export namespace Plugin {
     const client = createRailwiseClient({
       baseUrl: "http://localhost:4096",
       directory: Instance.directory,
+      headers: ServerAuth.headers(),
       // @ts-ignore - fetch type incompatibility
       fetch: async (...args) => Server.App().fetch(...args),
     })

--- a/packages/railwise/src/provider/transform.ts
+++ b/packages/railwise/src/provider/transform.ts
@@ -20,6 +20,10 @@ function mimeToModality(mime: string): Modality | undefined {
 export namespace ProviderTransform {
   export const OUTPUT_TOKEN_MAX = Flag.RAILWISE_EXPERIMENTAL_OUTPUT_TOKEN_MAX || 32_000
 
+  export function sanitizeSurrogates(content: string) {
+    return content.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "\uFFFD")
+  }
+
   // Maps npm package to the key the AI SDK expects for providerOptions
   function sdkKey(npm: string): string | undefined {
     switch (npm) {
@@ -49,6 +53,44 @@ export namespace ProviderTransform {
     model: Provider.Model,
     options: Record<string, unknown>,
   ): ModelMessage[] {
+    msgs = msgs.map((msg) => {
+      if (msg.role === "system") {
+        const content = msg.content as unknown
+        if (typeof content === "string") return { ...msg, content: sanitizeSurrogates(content) }
+        if (Array.isArray(content))
+          return {
+            ...msg,
+            content: content.map((part: any) => {
+              if (part.type === "text") return { ...part, text: sanitizeSurrogates(part.text) }
+              return part
+            }),
+          } as unknown as typeof msg
+        return msg
+      }
+      if (msg.role === "user") {
+        if (typeof msg.content === "string") return { ...msg, content: sanitizeSurrogates(msg.content) }
+        return {
+          ...msg,
+          content: msg.content.map((part) => {
+            if (part.type === "text") return { ...part, text: sanitizeSurrogates(part.text) }
+            return part
+          }),
+        }
+      }
+      if (msg.role === "assistant") {
+        if (typeof msg.content === "string") return { ...msg, content: sanitizeSurrogates(msg.content) }
+        return {
+          ...msg,
+          content: msg.content.map((part) => {
+            if (part.type === "text" || part.type === "reasoning")
+              return { ...part, text: sanitizeSurrogates(part.text) }
+            return part
+          }),
+        }
+      }
+      return msg
+    })
+
     // Anthropic rejects messages with empty content - filter out empty string messages
     // and remove empty text/reasoning parts from array content
     if (model.api.npm === "@ai-sdk/anthropic") {

--- a/packages/railwise/src/server/auth.ts
+++ b/packages/railwise/src/server/auth.ts
@@ -1,0 +1,10 @@
+import { Flag } from "@/flag/flag"
+
+export namespace ServerAuth {
+  export function headers(password = Flag.RAILWISE_SERVER_PASSWORD, username = Flag.RAILWISE_SERVER_USERNAME ?? "railwise") {
+    if (!password) return undefined
+    return {
+      Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`,
+    }
+  }
+}

--- a/packages/railwise/src/server/auth.ts
+++ b/packages/railwise/src/server/auth.ts
@@ -1,10 +1,40 @@
 import { Flag } from "@/flag/flag"
 
 export namespace ServerAuth {
-  export function headers(password = Flag.RAILWISE_SERVER_PASSWORD, username = Flag.RAILWISE_SERVER_USERNAME ?? "railwise") {
+  export function token(password = Flag.RAILWISE_SERVER_PASSWORD, username = Flag.RAILWISE_SERVER_USERNAME ?? "railwise") {
     if (!password) return undefined
+    return Buffer.from(`${username}:${password}`).toString("base64")
+  }
+
+  export function decode(token: string | undefined) {
+    if (!token) return undefined
+    const decoded = (() => {
+      try {
+        return Buffer.from(token, "base64").toString("utf8")
+      } catch {
+        return undefined
+      }
+    })()
+    if (!decoded) return undefined
+    const separator = decoded.indexOf(":")
+    if (separator === -1) return undefined
     return {
-      Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`,
+      username: decoded.slice(0, separator) || "railwise",
+      password: decoded.slice(separator + 1),
+    }
+  }
+
+  export function authorized(input: { token: string | undefined; username: string; password: string }) {
+    const decoded = decode(input.token)
+    if (!decoded) return false
+    return decoded.username === input.username && decoded.password === input.password
+  }
+
+  export function headers(password = Flag.RAILWISE_SERVER_PASSWORD, username = Flag.RAILWISE_SERVER_USERNAME ?? "railwise") {
+    const value = token(password, username)
+    if (!value) return undefined
+    return {
+      Authorization: `Basic ${value}`,
     }
   }
 }

--- a/packages/railwise/src/server/routes/agent-studio.ts
+++ b/packages/railwise/src/server/routes/agent-studio.ts
@@ -12,8 +12,8 @@ import { NormWiki } from "../../norm/wiki"
 import { Instance } from "../../project/instance"
 import { Session } from "../../session"
 import type { MessageV2 } from "../../session/message-v2"
-import { MessageTable } from "../../session/session.sql"
-import { Database, gte } from "../../storage/db"
+import { MessageTable, SessionTable } from "../../session/session.sql"
+import { and, Database, eq, gte } from "../../storage/db"
 import {
   AdjustmentConditionTool,
   AdjustmentFreeNetworkTool,
@@ -417,7 +417,14 @@ function calls() {
     db
       .select({ data: MessageTable.data })
       .from(MessageTable)
-      .where(gte(MessageTable.time_created, Date.now() - 7 * 24 * 60 * 60 * 1000))
+      .innerJoin(SessionTable, eq(MessageTable.session_id, SessionTable.id))
+      .where(
+        and(
+          eq(SessionTable.project_id, Instance.project.id),
+          eq(SessionTable.directory, Instance.directory),
+          gte(MessageTable.time_created, Date.now() - 7 * 24 * 60 * 60 * 1000),
+        ),
+      )
       .all(),
   )
   return rows.reduce(

--- a/packages/railwise/src/server/server.ts
+++ b/packages/railwise/src/server/server.ts
@@ -43,6 +43,7 @@ import { HTTPException } from "hono/http-exception"
 import { errors } from "./error"
 import { QuestionRoutes } from "./routes/question"
 import { PermissionRoutes } from "./routes/permission"
+import { ServerAuth } from "./auth"
 import { GlobalRoutes } from "./routes/global"
 import { MDNS } from "./mdns"
 
@@ -82,13 +83,23 @@ export namespace Server {
             status: 500,
           })
         })
-        .use((c, next) => {
+        .use(async (c, next) => {
           // Allow CORS preflight requests to succeed without auth.
           // Browser clients sending Authorization headers will preflight with OPTIONS.
           if (c.req.method === "OPTIONS") return next()
           const password = Flag.RAILWISE_SERVER_PASSWORD
           if (!password) return next()
           const username = Flag.RAILWISE_SERVER_USERNAME ?? "railwise"
+          const token = c.req.query("auth_token")
+          if (token) {
+            if (ServerAuth.authorized({ token, username, password })) return next()
+            return new Response("Unauthorized", {
+              status: 401,
+              headers: {
+                "WWW-Authenticate": 'Basic realm="Secure Area"',
+              },
+            })
+          }
           return basicAuth({ username, password })(c, next)
         })
         .use(async (c, next) => {

--- a/packages/railwise/src/session/retry.ts
+++ b/packages/railwise/src/session/retry.ts
@@ -8,6 +8,10 @@ export namespace SessionRetry {
   export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds
   export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for setTimeout
 
+  function cap(ms: number) {
+    return Math.min(ms, RETRY_MAX_DELAY)
+  }
+
   export async function sleep(ms: number, signal: AbortSignal): Promise<void> {
     return new Promise((resolve, reject) => {
       const abortHandler = () => {
@@ -33,7 +37,7 @@ export namespace SessionRetry {
         if (retryAfterMs) {
           const parsedMs = Number.parseFloat(retryAfterMs)
           if (!Number.isNaN(parsedMs)) {
-            return parsedMs
+            return cap(parsedMs)
           }
         }
 
@@ -42,27 +46,28 @@ export namespace SessionRetry {
           const parsedSeconds = Number.parseFloat(retryAfter)
           if (!Number.isNaN(parsedSeconds)) {
             // convert seconds to milliseconds
-            return Math.ceil(parsedSeconds * 1000)
+            return cap(Math.ceil(parsedSeconds * 1000))
           }
           // Try parsing as HTTP date format
           const parsed = Date.parse(retryAfter) - Date.now()
           if (!Number.isNaN(parsed) && parsed > 0) {
-            return Math.ceil(parsed)
+            return cap(Math.ceil(parsed))
           }
         }
 
-        return RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1)
+        return cap(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1))
       }
     }
 
-    return Math.min(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_NO_HEADERS)
+    return cap(Math.min(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_NO_HEADERS))
   }
 
   export function retryable(error: ReturnType<NamedError["toObject"]>) {
     // context overflow errors should not be retried
     if (MessageV2.ContextOverflowError.isInstance(error)) return undefined
     if (MessageV2.APIError.isInstance(error)) {
-      if (!error.data.isRetryable) return undefined
+      const status = error.data.statusCode
+      if (!error.data.isRetryable && !(status !== undefined && status >= 500)) return undefined
       if (error.data.responseBody?.includes("FreeUsageLimitError"))
         return `Free usage exceeded, add credits https://railwise.ai/zen`
       return error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message

--- a/packages/railwise/src/tool/tool.ts
+++ b/packages/railwise/src/tool/tool.ts
@@ -55,18 +55,20 @@ export namespace Tool {
         const toolInfo = init instanceof Function ? await init(initCtx) : init
         const execute = toolInfo.execute
         toolInfo.execute = async (args, ctx) => {
-          try {
-            toolInfo.parameters.parse(args)
-          } catch (error) {
-            if (error instanceof z.ZodError && toolInfo.formatValidationError) {
-              throw new Error(toolInfo.formatValidationError(error), { cause: error })
+          const params = (() => {
+            try {
+              return toolInfo.parameters.parse(args)
+            } catch (error) {
+              if (error instanceof z.ZodError && toolInfo.formatValidationError) {
+                throw new Error(toolInfo.formatValidationError(error), { cause: error })
+              }
+              throw new Error(
+                `The ${id} tool was called with invalid arguments: ${error}.\nPlease rewrite the input so it satisfies the expected schema.`,
+                { cause: error },
+              )
             }
-            throw new Error(
-              `The ${id} tool was called with invalid arguments: ${error}.\nPlease rewrite the input so it satisfies the expected schema.`,
-              { cause: error },
-            )
-          }
-          const result = await execute(args, ctx)
+          })()
+          const result = await execute(params, ctx)
           // skip truncation for tools that handle it themselves
           if (result.metadata.truncated !== undefined) {
             return result

--- a/packages/railwise/test/config/config.test.ts
+++ b/packages/railwise/test/config/config.test.ts
@@ -231,6 +231,33 @@ test("validates config schema and throws on invalid fields", async () => {
   })
 })
 
+test("loads desktop metadata and grouped legacy tools", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        $schema: "https://railwise.ai/config.json",
+        version: 1,
+        system: "desktop",
+        tools: {
+          bash: false,
+          surveying: ["rw_chainage_convert", "rw_coordinate_transform"],
+          monitoring: ["rw_trend_analysis"],
+        },
+      })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.permission?.bash).toBe("deny")
+      expect(config.permission?.rw_chainage_convert).toBe("allow")
+      expect(config.permission?.rw_coordinate_transform).toBe("allow")
+      expect(config.permission?.rw_trend_analysis).toBe("allow")
+    },
+  })
+})
+
 test("throws error for invalid JSON", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/railwise/test/mcp/output-schema.test.ts
+++ b/packages/railwise/test/mcp/output-schema.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, expect, mock, test } from "bun:test"
+
+const calls = {
+  listTools: 0,
+  request: 0,
+}
+
+mock.module("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: class MockStdio {
+    stderr = undefined
+    async close() {}
+  },
+}))
+
+mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: class MockClient {
+    async connect() {}
+    setNotificationHandler() {}
+    async close() {}
+    async listTools() {
+      calls.listTools++
+      throw new Error("outputSchema can't resolve reference #/$defs/missing")
+    }
+    async request() {
+      calls.request++
+      return {
+        tools: [
+          {
+            name: "repair-report",
+            description: "Create a repair report",
+            inputSchema: {
+              type: "object",
+              properties: {},
+            },
+            outputSchema: {
+              $ref: "#/$defs/missing",
+            },
+          },
+        ],
+      }
+    }
+  },
+}))
+
+beforeEach(() => {
+  calls.listTools = 0
+  calls.request = 0
+})
+
+const { MCP } = await import("../../src/mcp/index")
+const { Instance } = await import("../../src/project/instance")
+const { tmpdir } = await import("../fixture/fixture")
+
+test("keeps MCP tools when outputSchema validation fails", async () => {
+  await using tmp = await tmpdir()
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const added = await MCP.add("schema-server", {
+        type: "local",
+        command: ["schema-server"],
+      })
+
+      expect(added.status).toMatchObject({
+        "schema-server": {
+          status: "connected",
+        },
+      })
+
+      const tools = await MCP.tools()
+      expect(tools["schema-server_repair-report"]).toBeDefined()
+      expect(calls.listTools).toBe(2)
+      expect(calls.request).toBe(2)
+    },
+  })
+})

--- a/packages/railwise/test/provider/transform.test.ts
+++ b/packages/railwise/test/provider/transform.test.ts
@@ -847,6 +847,65 @@ describe("ProviderTransform.message - empty image handling", () => {
   })
 })
 
+describe("ProviderTransform.message - surrogate sanitization", () => {
+  const openaiModel = {
+    id: "openai/gpt-4",
+    providerID: "openai",
+    api: {
+      id: "gpt-4",
+      url: "https://api.openai.com",
+      npm: "@ai-sdk/openai",
+    },
+    name: "GPT-4",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: {
+      input: 0.03,
+      output: 0.06,
+      cache: { read: 0.001, write: 0.002 },
+    },
+    limit: {
+      context: 128000,
+      output: 4096,
+    },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2023-04-01",
+  } as any
+
+  test("replaces lone surrogates in text message parts", () => {
+    const msgs = [
+      { role: "system", content: "system\uD800" },
+      {
+        role: "user",
+        content: [{ type: "text", text: "user\uDFFF" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "thinking\uD800" },
+          { type: "text", text: "answer\uDFFF" },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, openaiModel, {}) as any[]
+
+    expect(result[0].content).toBe("system\uFFFD")
+    expect(result[1].content[0].text).toBe("user\uFFFD")
+    expect(result[2].content[0].text).toBe("thinking\uFFFD")
+    expect(result[2].content[1].text).toBe("answer\uFFFD")
+  })
+})
+
 describe("ProviderTransform.message - anthropic empty content filtering", () => {
   const anthropicModel = {
     id: "anthropic/claude-3-5-sonnet",

--- a/packages/railwise/test/server/agent-studio.test.ts
+++ b/packages/railwise/test/server/agent-studio.test.ts
@@ -128,6 +128,41 @@ describe("server.routes.agent-studio", () => {
     }
   })
 
+  test("agent call counts stay scoped to the current workspace", async () => {
+    await using tmp = await tmpdir()
+    const home = process.env.RAILWISE_TEST_HOME
+    process.env.RAILWISE_TEST_HOME = tmp.path
+    try {
+      const other = path.join(tmp.path, "other")
+      const current = path.join(tmp.path, "current")
+      await mkdir(other, { recursive: true })
+      await mkdir(current, { recursive: true })
+
+      await Instance.provide({
+        directory: other,
+        fn: async () => {
+          const session = await Session.create({ title: "Other project" })
+          const user = await writeUser(session.id, "Other project request")
+          await writeAssistant(session.id, user.id, "Other project response")
+        },
+      })
+
+      await Instance.provide({
+        directory: current,
+        fn: async () => {
+          const response = await AgentStudioRoutes().request("http://railwise.test/list")
+          const list = (await response.json()) as { name: string; callCount7d?: number }[]
+          const chief = list.find((agent: { name: string }) => agent.name === "chief_manager")
+
+          expect(response.status).toBe(200)
+          expect(chief?.callCount7d).toBe(0)
+        },
+      })
+    } finally {
+      restore(home)
+    }
+  })
+
   test("workflow run creates a session and returns a reusable prompt", async () => {
     await using tmp = await tmpdir()
     const home = process.env.RAILWISE_TEST_HOME

--- a/packages/railwise/test/server/auth.test.ts
+++ b/packages/railwise/test/server/auth.test.ts
@@ -16,3 +16,17 @@ test("server auth headers use configured username", () => {
 test("server auth headers are omitted when password is missing", () => {
   expect(ServerAuth.headers(undefined)).toBeUndefined()
 })
+
+test("server auth token decodes query credentials", () => {
+  const token = Buffer.from("kit:secret").toString("base64")
+
+  expect(ServerAuth.decode(token)).toEqual({ username: "kit", password: "secret" })
+  expect(ServerAuth.authorized({ token, username: "kit", password: "secret" })).toBe(true)
+  expect(ServerAuth.authorized({ token, username: "railwise", password: "secret" })).toBe(false)
+})
+
+test("server auth token defaults blank username to railwise", () => {
+  const token = Buffer.from(":secret").toString("base64")
+
+  expect(ServerAuth.decode(token)).toEqual({ username: "railwise", password: "secret" })
+})

--- a/packages/railwise/test/server/auth.test.ts
+++ b/packages/railwise/test/server/auth.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { ServerAuth } from "../../src/server/auth"
+
+test("server auth headers include basic auth when password is set", () => {
+  expect(ServerAuth.headers("secret")).toEqual({
+    Authorization: `Basic ${Buffer.from("railwise:secret").toString("base64")}`,
+  })
+})
+
+test("server auth headers use configured username", () => {
+  expect(ServerAuth.headers("secret", "operator")).toEqual({
+    Authorization: `Basic ${Buffer.from("operator:secret").toString("base64")}`,
+  })
+})
+
+test("server auth headers are omitted when password is missing", () => {
+  expect(ServerAuth.headers(undefined)).toBeUndefined()
+})

--- a/packages/railwise/test/session/retry.test.ts
+++ b/packages/railwise/test/session/retry.test.ts
@@ -4,11 +4,12 @@ import { APICallError } from "ai"
 import { SessionRetry } from "../../src/session/retry"
 import { MessageV2 } from "../../src/session/message-v2"
 
-function apiError(headers?: Record<string, string>): MessageV2.APIError {
+function apiError(headers?: Record<string, string>, data?: Partial<MessageV2.APIError["data"]>): MessageV2.APIError {
   return new MessageV2.APIError({
     message: "boom",
     isRetryable: true,
     responseHeaders: headers,
+    ...data,
   }).toObject() as MessageV2.APIError
 }
 
@@ -63,6 +64,11 @@ describe("session.retry.delay", () => {
 
     const longError = apiError({ "retry-after-ms": "700000" })
     expect(SessionRetry.delay(1, longError)).toBe(700000)
+  })
+
+  test("caps retry-after hints at the runtime timer limit", () => {
+    const error = apiError({ "retry-after-ms": "3000000000" })
+    expect(SessionRetry.delay(1, error)).toBe(SessionRetry.RETRY_MAX_DELAY)
   })
 
   test("sleep caps delay to max 32-bit signed integer to avoid TimeoutOverflowWarning", async () => {
@@ -120,6 +126,16 @@ describe("session.retry.retryable", () => {
     }).toObject() as ReturnType<NamedError["toObject"]>
 
     expect(SessionRetry.retryable(error)).toBeUndefined()
+  })
+
+  test("retries server errors even when provider did not mark them retryable", () => {
+    const error = apiError(undefined, {
+      message: "upstream failed",
+      statusCode: 503,
+      isRetryable: false,
+    })
+
+    expect(SessionRetry.retryable(error)).toBe("upstream failed")
   })
 })
 

--- a/packages/railwise/test/tool/tool.test.ts
+++ b/packages/railwise/test/tool/tool.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import z from "zod"
+import { Tool } from "../../src/tool/tool"
+
+const ctx: Tool.Context = {
+  sessionID: "ses_test",
+  messageID: "msg_test",
+  agent: "build",
+  abort: new AbortController().signal,
+  messages: [],
+  metadata() {},
+  ask: async () => {},
+}
+
+test("tool execution receives parsed parameters", async () => {
+  const schema = z.object({
+    count: z.coerce.number(),
+  })
+  const info = Tool.define("coerce", {
+    description: "test tool",
+    parameters: schema,
+    async execute(params) {
+      return {
+        title: "coerce",
+        output: `${typeof params.count}:${params.count}`,
+        metadata: {},
+      }
+    },
+  })
+
+  const tool = await info.init()
+  const result = await tool.execute({ count: "2" } as unknown as z.infer<typeof schema>, ctx)
+
+  expect(result.output).toBe("number:2")
+})

--- a/scripts/opencode-sync-audit.ts
+++ b/scripts/opencode-sync-audit.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env bun
+
+import { $ } from "bun"
+import { readdir } from "node:fs/promises"
+
+const base = process.argv[2] ?? "v1.4.5"
+const target = process.argv[3] ?? "v1.15.3"
+
+const bump = (map: Record<string, number>, key: string) => {
+  map[key] = (map[key] ?? 0) + 1
+}
+
+const table = (map: Record<string, number>) =>
+  Object.entries(map)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([key, count]) => `| ${key} | ${count} |`)
+    .join("\n")
+
+const diff = await $`git diff --name-status ${base}..${target} -- package.json bun.lock packages/opencode packages/app packages/ui packages/sdk/js`.text()
+const rows = diff
+  .trim()
+  .split("\n")
+  .filter(Boolean)
+  .map((line) => {
+    const parts = line.split(/\s+/)
+    return {
+      status: parts[0],
+      file: parts[parts.length - 1],
+    }
+  })
+
+const scopes: Record<string, number> = {}
+const statuses: Record<string, number> = {}
+const backend: Record<string, number> = {}
+const app: Record<string, number> = {}
+
+for (const row of rows) {
+  bump(statuses, row.status[0])
+  bump(scopes, row.file.startsWith("packages/") ? row.file.split("/").slice(0, 2).join("/") : row.file)
+  if (row.file.startsWith("packages/opencode/src/")) bump(backend, row.file.split("/")[3] ?? "(root)")
+  if (row.file.startsWith("packages/app/src/")) bump(app, row.file.split("/")[3] ?? "(root)")
+}
+
+const mapped = await Promise.all(
+  rows
+    .filter((row) => row.file.startsWith("packages/opencode/"))
+    .map(async (row) => {
+      const file = row.file.replace("packages/opencode/", "packages/railwise/")
+      return {
+        upstream: row.file,
+        railwise: file,
+        exists: await Bun.file(file).exists(),
+      }
+    }),
+)
+
+const upstream = new Set(
+  (
+    await $`git ls-tree -d --name-only ${`${target}:packages/opencode/src`}`.text()
+  )
+    .trim()
+    .split("\n")
+    .filter(Boolean),
+)
+const current = new Set(
+  (await readdir("packages/railwise/src", { withFileTypes: true }))
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name),
+)
+
+const missing = [...upstream].filter((name) => !current.has(name)).sort()
+const railwiseOnly = [...current].filter((name) => !upstream.has(name)).sort()
+const exists = mapped.filter((row) => row.exists).length
+const report = [
+  `# opencode ${target} Sync Audit`,
+  "",
+  `Generated from ${base}..${target}.`,
+  "",
+  "## Summary",
+  "",
+  `- Changed files in scoped paths: ${rows.length}`,
+  `- Upstream package path: packages/opencode`,
+  `- Railwise package path: packages/railwise`,
+  `- Direct git merge-base with Railwise HEAD: none expected for this fork snapshot`,
+  "",
+  "## Change Statuses",
+  "",
+  "| Status | Files |",
+  "| --- | ---: |",
+  table(statuses),
+  "",
+  "## Changed Scopes",
+  "",
+  "| Scope | Files |",
+  "| --- | ---: |",
+  table(scopes),
+  "",
+  "## Backend Modules Changed",
+  "",
+  "| packages/opencode/src module | Files |",
+  "| --- | ---: |",
+  table(backend),
+  "",
+  "## App Areas Changed",
+  "",
+  "| packages/app/src area | Files |",
+  "| --- | ---: |",
+  table(app),
+  "",
+  "## Railwise Mapping Coverage",
+  "",
+  `- Upstream packages/opencode changes: ${mapped.length}`,
+  `- Existing mapped Railwise files: ${exists}`,
+  `- Missing mapped Railwise files: ${mapped.length - exists}`,
+  "",
+  "## Upstream Modules Missing In Railwise",
+  "",
+  ...missing.map((name) => `- ${name}`),
+  "",
+  "## Railwise-Only Modules",
+  "",
+  ...railwiseOnly.map((name) => `- ${name}`),
+  "",
+  "## Recommended Migration Order",
+  "",
+  "1. Build and package scripts: keep Railwise naming, import upstream Windows/macOS build fixes only.",
+  "2. Config and schema: migrate tolerant parsing, permission/model/schema fixes, then regenerate SDK.",
+  "3. Server and session runtime: migrate API shape fixes, session sync, question handling, and event stream fixes.",
+  "4. Tool/plugin/provider layer: migrate MCP/tool compatibility and provider request fixes.",
+  "5. App shell: migrate prompt input, terminal websocket, global sync, and settings fixes while preserving Railwise agent studio.",
+  "6. Validation: run package typecheck, focused tests, desktop build, and installer smoke checks.",
+  "",
+].join("\n")
+
+console.log(report)


### PR DESCRIPTION
## Summary

This PR ports the high-signal opencode v1.15.3 changes into Railwise without wholesale replacing the Railwise product shell.

Included slices:

- ported Railwise build-script fixes from upstream opencode v1.15
- accepted desktop legacy config metadata safely
- hardened retry/runtime behavior
- tolerated invalid MCP output schemas
- passed local server auth into plugin SDK clients
- sanitized malformed provider text payloads
- executed parsed tool arguments after Zod validation/coercion
- stabilized app-shell workspace refresh keys, terminal WebSocket auth, and prompt comment context
- regenerated the JavaScript SDK and documented the no-diff result
- verified the unsigned Windows x64 internal installer route

## Verification

Local/package verification:

- `cd packages/railwise && bun run build --single --skip-install`
- `cd packages/railwise && bun test test/config/config.test.ts test/permission --timeout 30000`
- `cd packages/railwise && bun test test/server test/session --timeout 30000`
- `cd packages/railwise && bun test test/mcp --timeout 30000`
- `cd packages/railwise && bun test test/plugin test/server/auth.test.ts --timeout 30000`
- `cd packages/railwise && bun test test/provider/transform.test.ts --timeout 30000`
- `cd packages/railwise && bun test test/tool --timeout 30000`
- `cd packages/app && bun test --preload ./happydom.ts ./src --timeout 30000`
- `cd packages/app && bun run typecheck`
- `cd packages/railwise && bun run typecheck`
- `cd packages/desktop && bun run typecheck`
- `./packages/sdk/js/script/build.ts`
- `bun ./scripts/verify-desktop-windows-internal.ts`

GitHub Actions:

- Windows internal installer run: https://github.com/railwise-cn/RAILWISE-CLI/actions/runs/25984425985
- Result: success
- Artifact: `railwise-desktop-windows-x64-internal-1.3.0-internal.opencode-sync`
- Installer SHA256: `6b07c264c15d0acfce91da2c408abf70715d31c49fd46a974e25db6f4f421e18`

## Notes

This intentionally does not merge opencode wholesale. Railwise has product-specific Chinese desktop UI, multi-agent hub, workspace flow, release setup, and branding, so the migration keeps those boundaries and ports only the compatible runtime/build/app-shell fixes in reviewable slices.
