### PR TITLE
Stabilize Desktop single sidecar release builds

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -151,6 +151,7 @@ jobs:
 
       - name: Build sidecar
         if: matrix.platform != 'windows' || github.event_name != 'workflow_dispatch' || inputs.windows_unsigned_internal != true
+        timeout-minutes: 15
         run: bun run --cwd packages/desktop predev -- --target ${{ matrix.target }}
 
       - name: Build internal Windows sidecar

--- a/packages/railwise/script/build.ts
+++ b/packages/railwise/script/build.ts
@@ -53,7 +53,9 @@ console.log(`Loaded ${migrations.length} migrations`)
 
 const singleFlag = process.argv.includes("--single")
 const baselineFlag = process.argv.includes("--baseline")
-const skipInstall = process.argv.includes("--skip-install")
+// Single-target desktop sidecar builds already run after a frozen workspace install.
+// Reinstalling all OS/CPU native packages can hang CI on hosted Intel macOS runners.
+const skipInstall = process.argv.includes("--skip-install") || singleFlag
 const sourcemapsFlag = process.argv.includes("--sourcemaps")
 
 const allTargets: {


### PR DESCRIPTION
## Summary
- Skip all-platform native dependency reinstall for `--single` Railwise sidecar builds.
- Add a timeout to the Desktop Release sidecar build step so hosted runner stalls fail fast.

## Verification
- `cd packages/railwise && bun run typecheck`
- push hook: `bun turbo typecheck`

## Context
The macOS Intel beta release run stalled in `Build sidecar` after Bun reported integrity failures while downloading unrelated multi-platform native packages (`@esbuild/*`, `turbo-*`). Single-target sidecar builds already run after `bun install --frozen-lockfile`, so the all-OS/all-CPU reinstall is unnecessary for this path.