### PR TITLE
fix(desktop): open agent studio by default

### DIFF
--- a/packages/app/src/components/agent-card.test.tsx
+++ b/packages/app/src/components/agent-card.test.tsx
@@ -14,9 +14,9 @@ describe("AgentCard", () => {
   })
 
   test("maps known modes to Chinese labels", () => {
-    expect(modeLabel("primary")).toBe("主智能体")
-    expect(modeLabel("subagent")).toBe("子智能体")
-    expect(modeLabel("all")).toBe("通用")
+    expect(modeLabel("primary")).toBe("主控")
+    expect(modeLabel("subagent")).toBe("专业智能体")
+    expect(modeLabel("all")).toBe("专业智能体")
   })
 
   test("strips yaml frontmatter before markdown preview", () => {

--- a/packages/app/src/components/agent-card.tsx
+++ b/packages/app/src/components/agent-card.tsx
@@ -11,13 +11,15 @@ export function AgentCard(props: { agent: AgentStudioItem }) {
       href={`/agents/${props.agent.name}`}
       class="agent-card"
       data-testid={`agent-card-${props.agent.name}`}
-      aria-label={`打开 ${props.agent.name}`}
+      aria-label={`打开 ${props.agent.displayName ?? props.agent.name}`}
     >
       <div class="agent-card__top">
         <div class="agent-card__mark" style={{ "background-color": agentColor(props.agent.name, props.agent.color) }} />
         <div class="agent-card__title">
-          <h2>{props.agent.name}</h2>
-          <span>{modeLabel(props.agent.mode)}</span>
+          <h2>{props.agent.displayName ?? props.agent.name}</h2>
+          <span>
+            {modeLabel(props.agent.mode)} · @{props.agent.name}
+          </span>
         </div>
       </div>
       <p>{shortDescription(props.agent.description ?? props.agent.prompt ?? "暂无描述")}</p>

--- a/packages/app/src/components/agent-permission-form.tsx
+++ b/packages/app/src/components/agent-permission-form.tsx
@@ -37,7 +37,7 @@ export function AgentPermissionForm(props: { markdown: string; onChange: (value:
   return (
     <div class="agent-form" data-testid="agent-permission-form">
       <label class="agent-form__field">
-        <span>默认模型</span>
+        <span>智能体模型</span>
         <select
           value={value()}
           onInput={(event) =>
@@ -48,9 +48,10 @@ export function AgentPermissionForm(props: { markdown: string; onChange: (value:
             )
           }
         >
-          <option value="">继承系统默认</option>
+          <option value="">继承系统默认（建议 DeepSeek V4）</option>
           <For each={options()}>{(model) => <option value={model.value}>{model.label}</option>}</For>
         </select>
+        <small>未绑定时使用当前会话模型；绑定后这个智能体会优先使用所选模型。</small>
       </label>
 
       <For each={items}>

--- a/packages/app/src/components/workflow-gallery.tsx
+++ b/packages/app/src/components/workflow-gallery.tsx
@@ -238,7 +238,7 @@ export function WorkflowGallery() {
       <div class="agent-section__header">
         <div>
           <h2>工作流预设</h2>
-          <p>按行业模板串联 chief、researcher、writer、editor 等智能体。</p>
+          <p>按行业模板串联项目总控、外业首检、平差计算、报告编制和总工复核。</p>
         </div>
         <button type="button" class="agent-button" data-testid="workflow-run-btn" disabled={busy()} onClick={run}>
           导入预设

--- a/packages/app/src/pages/agents/[name].tsx
+++ b/packages/app/src/pages/agents/[name].tsx
@@ -53,7 +53,7 @@ export default function AgentDetailPage() {
     if (name === params.name) load()
   })
 
-  const title = createMemo(() => agent()?.name ?? params.name)
+  const title = createMemo(() => agent()?.displayName ?? agent()?.name ?? params.name)
   const summary = createMemo(() => shortDescription(agent()?.description ?? agent()?.prompt ?? "", 120))
 
   return (

--- a/packages/app/src/pages/agents/agent-studio.css
+++ b/packages/app/src/pages/agents/agent-studio.css
@@ -1,10 +1,10 @@
 .agent-studio {
-  --agent-bg: var(--bg-primary, rgb(251, 251, 249));
+  --agent-bg: var(--bg-primary, rgb(246, 248, 247));
   --agent-surface: var(--bg-secondary, rgb(255, 255, 255));
   --agent-text: var(--text-primary, rgb(10, 10, 9));
-  --agent-muted: var(--text-secondary, rgb(47, 38, 24));
-  --agent-accent: var(--accent-primary, rgba(117, 86, 32, 0.9));
-  --agent-accent-strong: var(--accent-secondary, rgb(95, 70, 24));
+  --agent-muted: var(--text-secondary, rgb(68, 82, 78));
+  --agent-accent: var(--accent-primary, rgb(15, 118, 110));
+  --agent-accent-strong: var(--accent-secondary, rgb(17, 94, 89));
   --agent-border: color-mix(in srgb, var(--agent-muted) 18%, transparent);
   --agent-soft: color-mix(in srgb, var(--agent-accent) 8%, transparent);
   --agent-shadow: var(--shadow-md, 0 4px 6px rgba(0, 0, 0, 0.07));
@@ -20,6 +20,380 @@
   color: var(--agent-text);
 }
 
+.agent-hero {
+  display: grid;
+  grid-template-columns: minmax(360px, 1.1fr) minmax(360px, 0.9fr);
+  gap: 24px;
+  align-items: stretch;
+  border: 1px solid var(--agent-border);
+  border-radius: var(--agent-radius);
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--agent-accent) 14%, transparent), transparent 42%),
+    var(--agent-surface);
+  padding: 24px;
+}
+
+.agent-hero__copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: center;
+  gap: 12px;
+}
+
+.agent-kicker {
+  color: var(--agent-accent-strong);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.agent-hero h1 {
+  margin: 0;
+  color: var(--agent-text);
+  font-size: 34px;
+  font-weight: 720;
+  line-height: 1.12;
+  letter-spacing: 0;
+}
+
+.agent-hero p {
+  max-width: 640px;
+  margin: 0;
+  color: var(--agent-muted);
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.agent-hero__stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.agent-stat {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid var(--agent-border);
+  border-radius: var(--agent-radius);
+  background: color-mix(in srgb, var(--agent-bg) 56%, var(--agent-surface));
+  padding: 14px;
+}
+
+.agent-stat span,
+.agent-stat small {
+  overflow: hidden;
+  color: var(--agent-muted);
+  font-size: 12px;
+  line-height: 1.45;
+  text-overflow: ellipsis;
+}
+
+.agent-stat strong {
+  color: var(--agent-text);
+  font-size: 30px;
+  font-weight: 720;
+  line-height: 1;
+}
+
+.agent-launch {
+  display: grid;
+  grid-template-columns: minmax(320px, 0.82fr) minmax(420px, 1.18fr);
+  gap: 14px;
+  border: 1px solid var(--agent-border);
+  border-radius: var(--agent-radius);
+  background: var(--agent-surface);
+  padding: 18px;
+}
+
+.agent-launch__project,
+.agent-launch__chat {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.agent-launch__path {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  gap: 10px;
+}
+
+.agent-launch__recent {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.agent-launch__recent button {
+  max-width: 100%;
+  min-height: 30px;
+  overflow: hidden;
+  border: 1px solid var(--agent-border);
+  border-radius: var(--agent-radius);
+  background: var(--agent-soft);
+  color: var(--agent-muted);
+  padding: 0 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-launch__recent button:hover {
+  border-color: color-mix(in srgb, var(--agent-accent) 56%, transparent);
+  color: var(--agent-accent-strong);
+}
+
+.agent-launch__chat-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  align-items: end;
+  gap: 10px;
+}
+
+.agent-rail {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.agent-model-routing {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 14px;
+  border: 1px solid var(--agent-border);
+  border-radius: var(--agent-radius);
+  background: var(--agent-surface);
+  padding: 18px;
+}
+
+.agent-model-routing__stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.agent-model-routing__stats div,
+.agent-model-routing__panel {
+  border: 1px solid var(--agent-border);
+  border-radius: var(--agent-radius);
+  background: color-mix(in srgb, var(--agent-bg) 56%, var(--agent-surface));
+}
+
+.agent-model-routing__stats div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+}
+
+.agent-model-routing__stats span,
+.agent-model-routing__stats small,
+.agent-model-routing__bar small,
+.agent-model-routing__empty small,
+.agent-model-item span,
+.agent-route-row small {
+  overflow: hidden;
+  color: var(--agent-muted);
+  font-size: 12px;
+  line-height: 1.45;
+  text-overflow: ellipsis;
+}
+
+.agent-model-routing__stats strong {
+  color: var(--agent-text);
+  font-size: 24px;
+  font-weight: 720;
+  line-height: 1;
+}
+
+.agent-model-routing__body {
+  display: grid;
+  grid-template-columns: minmax(300px, 0.82fr) minmax(420px, 1.18fr);
+  gap: 12px;
+}
+
+.agent-model-routing__panel {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+}
+
+.agent-model-routing__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.agent-model-routing__bar span,
+.agent-model-routing__empty strong,
+.agent-model-item strong,
+.agent-route-row strong {
+  overflow: hidden;
+  color: var(--agent-text);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-model-routing__empty {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  gap: 6px;
+  border-radius: 6px;
+  background: var(--agent-soft);
+  padding: 12px;
+}
+
+.agent-provider-actions {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 4px;
+}
+
+.agent-provider-actions button {
+  min-height: 30px;
+  border: 1px solid color-mix(in srgb, var(--agent-accent) 42%, var(--agent-border));
+  border-radius: var(--agent-radius);
+  background: var(--agent-surface);
+  color: var(--agent-accent-strong);
+  padding: 0 10px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.agent-model-list,
+.agent-route-list {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.agent-model-item,
+.agent-route-row {
+  min-width: 0;
+  border-radius: 6px;
+  background: var(--agent-soft);
+}
+
+.agent-model-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px;
+}
+
+.agent-route-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 0.65fr) minmax(260px, 1.35fr);
+  align-items: center;
+  gap: 10px;
+  padding: 9px 10px;
+}
+
+.agent-route-row > div:first-child {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.agent-route-row__controls {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(150px, 1fr) minmax(104px, 0.65fr) max-content;
+  align-items: center;
+  gap: 8px;
+}
+
+.agent-route-row__controls select {
+  width: 100%;
+}
+
+.agent-route-row__controls span {
+  overflow: hidden;
+  color: var(--agent-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-route-row a {
+  color: var(--agent-accent-strong);
+  font-size: 12px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.agent-rail__item {
+  display: flex;
+  min-width: 0;
+  min-height: 118px;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 10px;
+  border: 1px solid var(--agent-border);
+  border-radius: var(--agent-radius);
+  background: var(--agent-surface);
+  color: inherit;
+  padding: 13px;
+  text-decoration: none;
+}
+
+.agent-rail__item:hover {
+  border-color: color-mix(in srgb, var(--agent-accent) 60%, transparent);
+}
+
+.agent-rail__item span {
+  color: var(--agent-accent);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.agent-rail__item strong,
+.agent-rail__item small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.agent-rail__item strong {
+  color: var(--agent-text);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.25;
+  white-space: nowrap;
+}
+
+.agent-rail__item small {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  color: var(--agent-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
 .agent-toolbar,
 .agent-detail__bar,
 .agent-section__header {
@@ -30,6 +404,7 @@
 }
 
 .agent-toolbar h1,
+.agent-toolbar h2,
 .agent-detail__bar h1,
 .agent-section__header h2,
 .agent-panel__header h2 {
@@ -40,6 +415,7 @@
 }
 
 .agent-toolbar h1,
+.agent-toolbar h2,
 .agent-detail__bar h1 {
   font-size: 28px;
   line-height: 1.2;
@@ -59,6 +435,111 @@
   line-height: 1.5;
 }
 
+.agent-inventory {
+  display: grid;
+  grid-template-columns: minmax(360px, 1.15fr) minmax(320px, 0.85fr);
+  gap: 14px;
+}
+
+.agent-inventory__column {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 14px;
+  border: 1px solid var(--agent-border);
+  border-radius: var(--agent-radius);
+  background: var(--agent-surface);
+  padding: 18px;
+}
+
+.agent-tool-groups,
+.agent-skill-list {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.agent-tool-group {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.agent-tool-group__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.agent-tool-group__bar span {
+  color: var(--agent-text);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.agent-tool-group__bar small {
+  color: var(--agent-muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.agent-tool-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.agent-chip {
+  display: inline-flex;
+  max-width: 100%;
+  min-height: 28px;
+  align-items: center;
+  border: 1px solid var(--agent-border);
+  border-radius: 999px;
+  background: var(--agent-soft);
+  color: var(--agent-text);
+  font-size: 12px;
+  line-height: 1;
+  padding: 0 10px;
+}
+
+.agent-skill {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
+  border-radius: 6px;
+  background: var(--agent-soft);
+  padding: 10px;
+}
+
+.agent-skill strong,
+.agent-skill small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.agent-skill strong {
+  color: var(--agent-text);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.agent-skill small {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  color: var(--agent-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
 .agent-toolbar__controls {
   display: flex;
   gap: 10px;
@@ -67,7 +548,11 @@
 
 .agent-toolbar input,
 .agent-toolbar select,
-.agent-form select {
+.agent-form select,
+.agent-route-row select,
+.agent-launch input,
+.agent-launch select,
+.agent-launch textarea {
   min-height: 36px;
   border: 1px solid var(--agent-border);
   border-radius: var(--agent-radius);
@@ -75,6 +560,13 @@
   color: var(--agent-text);
   padding: 0 12px;
   outline: none;
+}
+
+.agent-launch textarea {
+  min-height: 104px;
+  resize: vertical;
+  padding: 10px 12px;
+  line-height: 1.55;
 }
 
 .agent-toolbar input {
@@ -815,6 +1307,12 @@
   font-weight: 650;
 }
 
+.agent-form__field > small {
+  color: var(--agent-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
 .agent-segment {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -840,6 +1338,17 @@
 }
 
 @media (max-width: 1160px) {
+  .agent-hero,
+  .agent-launch,
+  .agent-model-routing__body,
+  .agent-inventory {
+    grid-template-columns: 1fr;
+  }
+
+  .agent-rail {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   .agent-detail__grid {
     grid-template-columns: 1fr;
   }
@@ -856,12 +1365,17 @@
 
   .agent-toolbar,
   .agent-detail__bar,
+  .agent-launch__chat-head,
   .agent-section__header {
     align-items: stretch;
     flex-direction: column;
   }
 
   .agent-toolbar__controls,
+  .agent-hero__stats,
+  .agent-launch__path,
+  .agent-model-routing__stats,
+  .agent-rail,
   .workflow-tabs,
   .workflow-wiki {
     grid-template-columns: 1fr;
@@ -921,5 +1435,10 @@
 
   .agent-toolbar select {
     width: 100%;
+  }
+
+  .agent-route-row,
+  .agent-route-row__controls {
+    grid-template-columns: 1fr;
   }
 }

--- a/packages/app/src/pages/agents/api.ts
+++ b/packages/app/src/pages/agents/api.ts
@@ -3,6 +3,8 @@ import type {
   AgentStudioDetail,
   AgentStudioItem,
   FormatCoverageReport,
+  SkillInventoryItem,
+  ToolInventoryItem,
   WikiReportDetail,
   WikiStatus,
   WorkflowAcceptance,
@@ -39,6 +41,8 @@ export function useAgentStudioApi() {
 
   return {
     list: () => request<AgentStudioItem[]>("/list"),
+    tools: () => request<ToolInventoryItem[]>("/tool/list"),
+    skills: () => request<SkillInventoryItem[]>("/skill/list"),
     detail: (name: string) => request<AgentStudioDetail>(`/${encodeURIComponent(name)}`),
     update: (name: string, rawMarkdown: string) =>
       request<boolean>(`/${encodeURIComponent(name)}`, {

--- a/packages/app/src/pages/agents/collaboration.test.ts
+++ b/packages/app/src/pages/agents/collaboration.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test"
+import { base64Encode } from "@railwise/util/encode"
+import {
+  agentRoleLabel,
+  agentStudioSummary,
+  collaborationTarget,
+  modelRouteLabel,
+  modelRoutingSummary,
+  modelSetupState,
+  parseModelRoute,
+  professionalSkills,
+  recentWorkspaces,
+  recommendedProviders,
+  updateAgentModelRoute,
+} from "./collaboration"
+
+describe("collaborationTarget", () => {
+  test("builds a workspace session handoff with the selected agent", () => {
+    const target = collaborationTarget({
+      directory: "/Users/WANGJIAWEI/CODE/RAILWISE-CLI/",
+      agent: "chief_manager",
+      prompt: "  检查当前工程资料并列出下一步  ",
+    })
+
+    expect(target.directory).toBe("/Users/WANGJIAWEI/CODE/RAILWISE-CLI")
+    expect(target.key).toBe(base64Encode("/Users/WANGJIAWEI/CODE/RAILWISE-CLI"))
+    expect(target.href).toBe(`/${base64Encode("/Users/WANGJIAWEI/CODE/RAILWISE-CLI")}/session`)
+    expect(target.prompt).toBe("@chief_manager\n检查当前工程资料并列出下一步")
+  })
+})
+
+describe("model routing helpers", () => {
+  test("deduplicates recent workspaces and hides the global root placeholder", () => {
+    const list = recentWorkspaces(
+      [
+        { worktree: "/Users/me/CODE/RAILWISE-CLI", time: { created: 1, updated: 10 } },
+        { worktree: "/", time: { created: 1, updated: 40 } },
+        { worktree: "/Users/me/CODE/RAILWISE-CLI/", time: { created: 1, updated: 30 } },
+        { worktree: "/Users/me/CODE/RAILWISE-Desktop", time: { created: 1, updated: 20 } },
+      ],
+      4,
+    )
+
+    expect(list.map((project) => project.worktree)).toEqual([
+      "/Users/me/CODE/RAILWISE-CLI",
+      "/Users/me/CODE/RAILWISE-Desktop",
+    ])
+  })
+
+  test("summarizes primary and professional collaborators for Agent Studio", () => {
+    const summary = agentStudioSummary([
+      { name: "chief_manager", mode: "primary" },
+      { name: "solution_architect", mode: "all" },
+      { name: "ppt_master", mode: "subagent" },
+      { name: "hidden", mode: "subagent", hidden: true },
+    ])
+
+    expect(summary.total).toBe(3)
+    expect(summary.primary).toBe(1)
+    expect(summary.collaborators).toBe(2)
+  })
+
+  test("uses product-facing role labels instead of coding agent terms", () => {
+    expect(agentRoleLabel({ name: "chief_manager", mode: "primary" })).toBe("主控")
+    expect(agentRoleLabel({ name: "solution_architect", mode: "all" })).toBe("专业智能体")
+    expect(agentRoleLabel({ name: "ppt_master", mode: "subagent" })).toBe("专业智能体")
+  })
+
+  test("summarizes bound and defaulted agent models", () => {
+    const summary = modelRoutingSummary([
+      { name: "chief_manager", mode: "primary", model: { providerID: "deepseek", modelID: "deepseek-v4" } },
+      { name: "writer", mode: "subagent" },
+      { name: "hidden", mode: "subagent", hidden: true },
+    ])
+
+    expect(summary.total).toBe(2)
+    expect(summary.bound).toBe(1)
+    expect(summary.defaulted).toBe(1)
+    expect(summary.recommended).toBe("DeepSeek V4")
+  })
+
+  test("labels bound models and default fallback", () => {
+    expect(modelRouteLabel({ name: "chief_manager", mode: "primary", model: { providerID: "deepseek", modelID: "v4" } })).toBe(
+      "deepseek/v4",
+    )
+    expect(modelRouteLabel({ name: "writer", mode: "subagent" })).toBe("默认 DeepSeek V4")
+  })
+
+  test("detects model onboarding state from providers and visible models", () => {
+    expect(modelSetupState({ connectedProviders: 0, visibleModels: 0 })).toBe("needs-provider")
+    expect(modelSetupState({ connectedProviders: 1, visibleModels: 0 })).toBe("models-hidden")
+    expect(modelSetupState({ connectedProviders: 1, visibleModels: 3 })).toBe("ready")
+  })
+
+  test("prioritizes DeepSeek and OpenRouter for Agent Studio onboarding", () => {
+    expect(recommendedProviders.map((provider) => provider.id)).toEqual(["deepseek", "openrouter"])
+  })
+
+  test("prioritizes Railwise professional skills over generic automation skills", () => {
+    const skills = professionalSkills(
+      [
+        { name: "qa", description: "generic qa", location: "/Users/me/.agents/skills/gstack/qa/SKILL.md" },
+        {
+          name: "monitoring-design",
+          description: "工程监测方案设计",
+          location: "/repo/.railwise/skill/monitoring-design/SKILL.md",
+        },
+        {
+          name: "standard-reference",
+          description: "规范条文速查",
+          location: "/repo/.railwise/skill/standard-reference/SKILL.md",
+        },
+        {
+          name: "data-analysis",
+          description: "测绘数据平差与变形分析",
+          location: "/repo/.railwise/skill/data-analysis/SKILL.md",
+        },
+      ],
+      3,
+    )
+
+    expect(skills.map((skill) => skill.name)).toEqual(["monitoring-design", "data-analysis", "standard-reference"])
+  })
+
+  test("parses provider and model route from the matrix select value", () => {
+    expect(parseModelRoute("deepseek/deepseek-v4")).toEqual({ providerID: "deepseek", modelID: "deepseek-v4" })
+    expect(parseModelRoute("openrouter/anthropic/claude-sonnet-4.5")).toEqual({
+      providerID: "openrouter",
+      modelID: "anthropic/claude-sonnet-4.5",
+    })
+    expect(parseModelRoute("")).toBeUndefined()
+    expect(parseModelRoute("invalid")).toBeUndefined()
+  })
+
+  test("updates agent markdown model binding from the route matrix", () => {
+    const raw = "---\ndescription: test\nmodel: railwise/auto\n---\n\nbody"
+    const updated = updateAgentModelRoute(raw, "deepseek/deepseek-v4")
+
+    expect(updated).toContain("model: deepseek/deepseek-v4")
+    expect(updateAgentModelRoute(updated, "")).not.toContain("model:")
+  })
+})

--- a/packages/app/src/pages/agents/collaboration.ts
+++ b/packages/app/src/pages/agents/collaboration.ts
@@ -1,0 +1,156 @@
+import { base64Encode } from "@railwise/util/encode"
+import { removeScalar, setScalar } from "@/utils/agent-markdown"
+
+export const recommendedModel = "DeepSeek V4"
+export const recommendedProviders = [
+  { id: "deepseek", label: "DeepSeek" },
+  { id: "openrouter", label: "OpenRouter" },
+] as const
+
+export type CollaborationDraft = {
+  directory: string
+  agent: string
+  prompt: string
+}
+
+type WorkspaceProject = {
+  worktree: string
+  time: {
+    created: number
+    updated?: number
+  }
+}
+
+type Agent = {
+  name: string
+  mode: "subagent" | "primary" | "all"
+  hidden?: boolean
+  model?: {
+    providerID: string
+    modelID: string
+  }
+}
+
+type Skill = {
+  name: string
+  description: string
+  location: string
+}
+
+const skills = [
+  "monitoring-design",
+  "data-analysis",
+  "standard-reference",
+  "report-writing",
+  "excel-operations",
+  "docx-generation",
+  "canvas-design",
+  "bidding-knowledge",
+  "humanizer",
+  "frontend-design",
+]
+
+export function agentRoleLabel(agent: Agent) {
+  if (agent.mode === "primary") return "主控"
+  return "专业智能体"
+}
+
+export function agentStudioSummary(agents: Agent[]) {
+  const visible = agents.filter((agent) => !agent.hidden)
+  const primary = visible.filter((agent) => agent.mode === "primary").length
+  return {
+    total: visible.length,
+    primary,
+    collaborators: visible.length - primary,
+  }
+}
+
+function normalizeDirectory(value: string) {
+  const clean = value.trim().replaceAll("\\", "/")
+  if (clean === "/") return clean
+  if (/^[A-Za-z]:\/$/.test(clean)) return clean
+  return clean.replace(/\/+$/, "")
+}
+
+export function recentWorkspaces(projects: WorkspaceProject[], limit = 4) {
+  const seen = new Set<string>()
+  return projects
+    .map((project) => ({
+      ...project,
+      worktree: normalizeDirectory(project.worktree),
+    }))
+    .filter((project) => project.worktree && project.worktree !== "/")
+    .sort((a, b) => (b.time.updated ?? b.time.created) - (a.time.updated ?? a.time.created))
+    .filter((project) => {
+      if (seen.has(project.worktree)) return false
+      seen.add(project.worktree)
+      return true
+    })
+    .slice(0, limit)
+}
+
+function skillRank(skill: Skill) {
+  const index = skills.indexOf(skill.name)
+  if (index >= 0) return index
+  if (skill.location.includes("/.railwise/skill/")) return skills.length
+  return skills.length + 1
+}
+
+export function professionalSkills(list: Skill[], limit = 12) {
+  return list
+    .slice()
+    .sort((a, b) => skillRank(a) - skillRank(b) || a.name.localeCompare(b.name, "zh-Hans-CN"))
+    .slice(0, limit)
+}
+
+export function collaborationTarget(input: CollaborationDraft) {
+  const directory = normalizeDirectory(input.directory)
+  const key = base64Encode(directory)
+  const agent = input.agent.trim()
+  const prompt = input.prompt.trim()
+
+  return {
+    directory,
+    key,
+    href: `/${key}/session`,
+    prompt: agent ? `@${agent}\n${prompt}` : prompt,
+  }
+}
+
+export function modelRouteLabel(agent: Agent, fallback = recommendedModel) {
+  if (agent.model) return `${agent.model.providerID}/${agent.model.modelID}`
+  return `默认 ${fallback}`
+}
+
+export function modelRoutingSummary(agents: Agent[]) {
+  const visible = agents.filter((agent) => !agent.hidden)
+  const bound = visible.filter((agent) => Boolean(agent.model)).length
+  return {
+    total: visible.length,
+    bound,
+    defaulted: visible.length - bound,
+    recommended: recommendedModel,
+  }
+}
+
+export function modelSetupState(input: { connectedProviders: number; visibleModels: number }) {
+  if (input.visibleModels > 0) return "ready" as const
+  if (input.connectedProviders > 0) return "models-hidden" as const
+  return "needs-provider" as const
+}
+
+export function parseModelRoute(value: string) {
+  const route = value.trim()
+  const index = route.indexOf("/")
+  if (index <= 0 || index === route.length - 1) return
+  return {
+    providerID: route.slice(0, index),
+    modelID: route.slice(index + 1),
+  }
+}
+
+export function updateAgentModelRoute(raw: string, value: string) {
+  const route = value.trim()
+  if (!route) return removeScalar(raw, "model")
+  return setScalar(raw, "model", route)
+}

--- a/packages/app/src/pages/agents/index.tsx
+++ b/packages/app/src/pages/agents/index.tsx
@@ -1,59 +1,525 @@
 import "./agent-studio.css"
-import { createMemo, createSignal, For, onMount, Show } from "solid-js"
+import { A, useNavigate } from "@solidjs/router"
+import { createEffect, createMemo, createSignal, For, onMount, Show } from "solid-js"
+import { useDialog } from "@railwise/ui/context/dialog"
 import { AgentCard } from "@/components/agent-card"
+import { DialogConnectProvider } from "@/components/dialog-connect-provider"
+import { DialogSelectDirectory } from "@/components/dialog-select-directory"
+import { DialogSelectProvider } from "@/components/dialog-select-provider"
 import { WorkflowGallery } from "@/components/workflow-gallery"
+import { useGlobalSync } from "@/context/global-sync"
+import { useLayout } from "@/context/layout"
+import { useModels } from "@/context/models"
+import { usePlatform } from "@/context/platform"
+import { useServer } from "@/context/server"
 import { useAgentUpdates } from "@/hooks/use-agent-updates"
-import type { AgentMode, AgentStudioItem } from "@/types/agent-studio"
+import { useProviders } from "@/hooks/use-providers"
+import { setSessionHandoff } from "@/pages/session/handoff"
+import type { AgentStudioItem, SkillInventoryItem, ToolInventoryItem } from "@/types/agent-studio"
 import { useAgentStudioApi } from "./api"
+import {
+  agentRoleLabel,
+  agentStudioSummary,
+  collaborationTarget,
+  modelRouteLabel,
+  modelRoutingSummary,
+  modelSetupState,
+  parseModelRoute,
+  professionalSkills,
+  recentWorkspaces,
+  recommendedModel,
+  recommendedProviders,
+  updateAgentModelRoute,
+} from "./collaboration"
 
 const modes = [
   { value: "all", label: "全部" },
-  { value: "primary", label: "主智能体" },
-  { value: "subagent", label: "子智能体" },
+  { value: "primary", label: "主控智能体" },
+  { value: "collaborator", label: "专业智能体" },
 ] as const
 type ModeFilter = (typeof modes)[number]["value"]
 
+const groups: Record<ToolInventoryItem["group"], string> = {
+  agent: "智能体协作",
+  knowledge: "规范知识",
+  survey: "测绘生产",
+  core: "基础执行",
+  extension: "扩展能力",
+}
+
+const focus = [
+  "chief_manager",
+  "cpiii_specialist",
+  "adjustment_computer",
+  "norm_librarian",
+  "knowledge_curator",
+  "source_ingestor",
+]
+
+function result<T>(value: PromiseSettledResult<T>, fallback: T) {
+  if (value.status === "fulfilled") return value.value
+  return fallback
+}
+
 export default function AgentsPage() {
   const api = useAgentStudioApi()
+  const dialog = useDialog()
+  const layout = useLayout()
+  const navigate = useNavigate()
+  const models = useModels()
+  const platform = usePlatform()
+  const providers = useProviders()
+  const server = useServer()
+  const sync = useGlobalSync()
   const [items, setItems] = createSignal<AgentStudioItem[]>([])
+  const [tools, setTools] = createSignal<ToolInventoryItem[]>([])
+  const [skills, setSkills] = createSignal<SkillInventoryItem[]>([])
+  const [directory, setDirectory] = createSignal("")
+  const [manualDirectory, setManualDirectory] = createSignal(false)
+  const [selectedAgent, setSelectedAgent] = createSignal("chief_manager")
+  const [draft, setDraft] = createSignal("")
   const [query, setQuery] = createSignal("")
   const [mode, setMode] = createSignal<ModeFilter>("all")
   const [loading, setLoading] = createSignal(true)
   const [error, setError] = createSignal("")
+  const [routeSaving, setRouteSaving] = createSignal<Record<string, boolean>>({})
 
   function load() {
     setLoading(true)
-    void api
-      .list()
-      .then((agents) => {
-        setItems(agents)
-        setError("")
+    void Promise.allSettled([api.list(), api.tools(), api.skills()])
+      .then(([agents, toolset, skillset]) => {
+        if (agents.status === "fulfilled") {
+          setItems(agents.value)
+          setError("")
+        } else {
+          setError(agents.reason instanceof Error ? agents.reason.message : String(agents.reason))
+        }
+        setTools(result(toolset, []))
+        setSkills(result(skillset, []))
       })
-      .catch((err: unknown) => setError(err instanceof Error ? err.message : String(err)))
       .finally(() => setLoading(false))
   }
 
   onMount(load)
   useAgentUpdates(load)
 
+  const recent = createMemo(() =>
+    recentWorkspaces(sync.data.project, 4),
+  )
+  const summary = createMemo(() => agentStudioSummary(items()))
+  const collaborators = createMemo(() =>
+    items()
+      .slice()
+      .sort(
+        (a, b) =>
+          Number(a.mode !== "primary") - Number(b.mode !== "primary") ||
+          a.name.localeCompare(b.name, "zh-Hans-CN"),
+      ),
+  )
+  const featured = createMemo(() =>
+    focus
+      .map((name) => items().find((agent) => agent.name === name))
+      .filter((agent): agent is AgentStudioItem => Boolean(agent))
+      .slice(0, 6),
+  )
+  const grouped = createMemo(() =>
+    (Object.keys(groups) as ToolInventoryItem["group"][])
+      .map((group) => ({
+        group,
+        label: groups[group],
+        items: tools().filter((tool) => tool.group === group),
+      }))
+      .filter((group) => group.items.length > 0),
+  )
+  const visibleSkills = createMemo(() => professionalSkills(skills(), 12))
+  const visibleModels = createMemo(() =>
+    models.list().filter((model) => models.visible({ providerID: model.provider.id, modelID: model.id })),
+  )
+  const connectedProviders = createMemo(() => providers.connected().filter((provider) => provider.id !== "railwise"))
+  const routeSummary = createMemo(() => modelRoutingSummary(items()))
+  const setupState = createMemo(() =>
+    modelSetupState({ connectedProviders: connectedProviders().length, visibleModels: visibleModels().length }),
+  )
+  const routedAgents = createMemo(() => collaborators().slice(0, 8))
+  const visibleModelPreview = createMemo(() =>
+    visibleModels()
+      .slice()
+      .sort((a, b) => a.provider.name.localeCompare(b.provider.name) || a.name.localeCompare(b.name))
+      .slice(0, 6),
+  )
+  const modelOptions = createMemo(() =>
+    visibleModels()
+      .slice()
+      .sort((a, b) => a.provider.name.localeCompare(b.provider.name) || a.name.localeCompare(b.name))
+      .map((model) => ({
+        value: `${model.provider.id}/${model.id}`,
+        label: `${model.provider.name} / ${model.name}`,
+      })),
+  )
+  const canStart = createMemo(
+    () => directory().trim().length > 0 && selectedAgent().trim().length > 0 && draft().trim().length > 0,
+  )
+
   const filtered = createMemo(() => {
     const needle = query().trim().toLowerCase()
     return items().filter((agent) => {
-      const visible = mode() === "all" || agent.mode === (mode() as AgentMode)
+      const visible =
+        mode() === "all" ||
+        (mode() === "primary" && agent.mode === "primary") ||
+        (mode() === "collaborator" && agent.mode !== "primary")
       const found =
         !needle ||
         agent.name.toLowerCase().includes(needle) ||
+        (agent.displayName ?? "").toLowerCase().includes(needle) ||
         (agent.description ?? agent.prompt ?? "").toLowerCase().includes(needle)
       return visible && found
     })
   })
 
+  const compactPath = (value: string) => {
+    const home = sync.data.path.home
+    if (home && value === home) return "~"
+    if (home && value.startsWith(home + "/")) return "~" + value.slice(home.length)
+    return value
+  }
+
+  const updateDirectory = (value: string) => {
+    setManualDirectory(true)
+    setDirectory(value)
+  }
+
+  const chooseDirectory = async () => {
+    const resolve = (value: string | string[] | null) => {
+      const next = Array.isArray(value) ? value[0] : value
+      if (next) updateDirectory(next)
+    }
+
+    if (platform.openDirectoryPickerDialog && server.isLocal()) {
+      resolve(
+        await platform.openDirectoryPickerDialog({
+          title: "选择工作区文件夹",
+          multiple: false,
+        }),
+      )
+      return
+    }
+    dialog.show(
+      () => <DialogSelectDirectory title="选择工作区文件夹" onSelect={resolve} />,
+      () => resolve(null),
+    )
+  }
+
+  const connectProvider = () => {
+    dialog.show(() => <DialogSelectProvider />)
+  }
+
+  const connectPreferred = (id: string) => {
+    if (!providers.all().some((provider) => provider.id === id)) {
+      connectProvider()
+      return
+    }
+    dialog.show(() => <DialogConnectProvider provider={id} />)
+  }
+
+  const routeValue = (agent: AgentStudioItem) => {
+    if (!agent.model) return ""
+    return `${agent.model.providerID}/${agent.model.modelID}`
+  }
+
+  const routeOptions = (agent: AgentStudioItem) => {
+    const current = routeValue(agent)
+    if (!current || modelOptions().some((model) => model.value === current)) return modelOptions()
+    return [{ value: current, label: `当前绑定 ${current}` }, ...modelOptions()]
+  }
+
+  const updateRouteSaving = (name: string, saving: boolean) => {
+    setRouteSaving((state) => {
+      if (saving) return { ...state, [name]: true }
+      const next = { ...state }
+      delete next[name]
+      return next
+    })
+  }
+
+  const saveRoute = async (agent: AgentStudioItem, value: string) => {
+    const route = parseModelRoute(value)
+    if (value && !route) return
+    updateRouteSaving(agent.name, true)
+    try {
+      const detail = await api.detail(agent.name)
+      await api.update(agent.name, updateAgentModelRoute(detail.rawMarkdown, value))
+      setItems((current) =>
+        current.map((item) =>
+          item.name === agent.name
+            ? {
+                ...item,
+                model: route,
+              }
+            : item,
+        ),
+      )
+      setError("")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      updateRouteSaving(agent.name, false)
+    }
+  }
+
+  const startCollaboration = () => {
+    if (!canStart()) return
+    const target = collaborationTarget({
+      directory: directory(),
+      agent: selectedAgent(),
+      prompt: draft(),
+    })
+    layout.projects.open(target.directory)
+    server.projects.touch(target.directory)
+    setSessionHandoff(target.key, { prompt: target.prompt })
+    navigate(target.href)
+  }
+
+  createEffect(() => {
+    if (manualDirectory() || directory()) return
+    const current = server.projects.last() ?? recent()[0]?.worktree
+    if (current) setDirectory(current)
+  })
+
+  createEffect(() => {
+    const current = selectedAgent()
+    if (items().some((agent) => agent.name === current)) return
+    const chief = items().find((agent) => agent.name === "chief_manager")
+    const first = chief ?? items()[0]
+    if (first) setSelectedAgent(first.name)
+  })
+
   return (
     <main class="agent-studio" data-testid="agents-page">
+      <section class="agent-hero">
+        <div class="agent-hero__copy">
+          <span class="agent-kicker">RAILWISE Agent Studio</span>
+          <h1>多智能体协作中枢</h1>
+          <p>围绕工程测绘任务组织专业智能体、生产工具、Skills 与工作流，让一次会话直接进入执行。</p>
+        </div>
+        <div class="agent-hero__stats" aria-busy={loading()}>
+          <div class="agent-stat">
+            <span>智能体</span>
+            <strong>{summary().total}</strong>
+            <small>{summary().primary} 主控 / {summary().collaborators} 专业智能体</small>
+          </div>
+          <div class="agent-stat">
+            <span>工具</span>
+            <strong>{tools().length}</strong>
+            <small>调度、规范、平差、文件执行</small>
+          </div>
+          <div class="agent-stat">
+            <span>Skills</span>
+            <strong>{skills().length}</strong>
+            <small>可按任务加载的专业流程</small>
+          </div>
+        </div>
+      </section>
+
+      <section class="agent-launch" data-testid="agent-collaboration-start">
+        <div class="agent-launch__project">
+          <div class="agent-section__header">
+            <div>
+              <h2>项目工作区</h2>
+              <p>以本地文件夹作为上下文，智能体直接在这个目录里工作。</p>
+            </div>
+          </div>
+          <label class="agent-form__field">
+            <span>工作区文件夹</span>
+            <div class="agent-launch__path">
+              <input
+                data-testid="agent-project-directory"
+                value={directory()}
+                onInput={(event) => updateDirectory(event.currentTarget.value)}
+                placeholder="/Users/name/CODE/project"
+              />
+              <button type="button" class="agent-button agent-button--ghost" onClick={chooseDirectory}>
+                选择文件夹
+              </button>
+            </div>
+          </label>
+          <Show when={recent().length}>
+            <div class="agent-launch__recent" aria-label="最近工作区">
+              <For each={recent()}>
+                {(project) => (
+                  <button type="button" title={project.worktree} onClick={() => updateDirectory(project.worktree)}>
+                    {compactPath(project.worktree)}
+                  </button>
+                )}
+              </For>
+            </div>
+          </Show>
+        </div>
+
+        <form
+          class="agent-launch__chat"
+          onSubmit={(event) => {
+            event.preventDefault()
+            startCollaboration()
+          }}
+        >
+          <div class="agent-launch__chat-head">
+            <label class="agent-form__field">
+              <span>协作智能体</span>
+              <select
+                data-testid="agent-collaboration-agent"
+                value={selectedAgent()}
+                onInput={(event) => setSelectedAgent(event.currentTarget.value)}
+              >
+                <Show
+                  when={collaborators().length}
+                  fallback={<option value={selectedAgent()}>{selectedAgent()}</option>}
+                >
+                  <For each={collaborators()}>
+                    {(agent) => (
+                      <option value={agent.name}>
+                        {agent.displayName ?? agent.name} · {agentRoleLabel(agent)} · @{agent.name}
+                      </option>
+                    )}
+                  </For>
+                </Show>
+              </select>
+            </label>
+            <button type="submit" class="agent-button" data-testid="agent-start-session" disabled={!canStart()}>
+              开始协作
+            </button>
+          </div>
+          <label class="agent-form__field">
+            <span>任务输入</span>
+            <textarea
+              data-testid="agent-collaboration-prompt"
+              value={draft()}
+              onInput={(event) => setDraft(event.currentTarget.value)}
+              placeholder="告诉智能体要完成的任务，例如：检查当前线路复测资料，列出缺失文件并给出下一步执行计划。"
+            />
+          </label>
+        </form>
+      </section>
+
+      <section class="agent-model-routing" data-testid="agent-model-routing">
+        <div class="agent-section__header">
+          <div>
+            <h2>模型接入与智能体路由</h2>
+            <p>默认建议 {recommendedModel}；主控、审校、平差等智能体可以分别绑定不同模型。</p>
+          </div>
+          <button type="button" class="agent-button" onClick={connectProvider}>
+            接入模型
+          </button>
+        </div>
+
+        <div class="agent-model-routing__stats">
+          <div>
+            <span>已接入 Provider</span>
+            <strong>{connectedProviders().length}</strong>
+            <small>{setupState() === "needs-provider" ? "建议先接入 DeepSeek 或 OpenRouter" : "可用于模型路由"}</small>
+          </div>
+          <div>
+            <span>可见模型</span>
+            <strong>{visibleModels().length}</strong>
+            <small>{setupState() === "models-hidden" ? "Provider 已接入，需启用模型" : `默认建议 ${recommendedModel}`}</small>
+          </div>
+          <div>
+            <span>专属绑定</span>
+            <strong>{routeSummary().bound}</strong>
+            <small>{routeSummary().defaulted} 个智能体继承默认模型</small>
+          </div>
+        </div>
+
+        <div class="agent-model-routing__body">
+          <div class="agent-model-routing__panel">
+            <div class="agent-model-routing__bar">
+              <span>模型接入</span>
+              <small>{setupState() === "ready" ? "已可用" : "待配置"}</small>
+            </div>
+            <Show
+              when={visibleModelPreview().length}
+              fallback={
+                <div class="agent-model-routing__empty">
+                  <strong>还没有可用模型</strong>
+                  <small>点击“接入模型”，添加 DeepSeek、OpenRouter 或 OpenAI 兼容模型后即可分配给智能体。</small>
+                  <div class="agent-provider-actions">
+                    <For each={recommendedProviders}>
+                      {(provider) => (
+                        <button type="button" onClick={() => connectPreferred(provider.id)}>
+                          接入 {provider.label}
+                        </button>
+                      )}
+                    </For>
+                  </div>
+                </div>
+              }
+            >
+              <div class="agent-model-list">
+                <For each={visibleModelPreview()}>
+                  {(model) => (
+                    <div class="agent-model-item">
+                      <strong>{model.provider.name}</strong>
+                      <span>{model.name}</span>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </Show>
+          </div>
+
+          <div class="agent-model-routing__panel">
+            <div class="agent-model-routing__bar">
+              <span>智能体模型矩阵</span>
+              <small>{routeSummary().total} 个可见智能体</small>
+            </div>
+            <div class="agent-route-list">
+              <For each={routedAgents()}>
+                {(agent) => (
+                  <div class="agent-route-row">
+                    <div>
+                      <strong>{agent.displayName ?? agent.name}</strong>
+                      <small>{agentRoleLabel(agent)}</small>
+                    </div>
+                    <div class="agent-route-row__controls">
+                      <select
+                        aria-label={`设置 ${agent.name} 模型`}
+                        value={routeValue(agent)}
+                        disabled={routeSaving()[agent.name] || (!modelOptions().length && !routeValue(agent))}
+                        onInput={(event) => void saveRoute(agent, event.currentTarget.value)}
+                      >
+                        <option value="">默认 {recommendedModel}</option>
+                        <For each={routeOptions(agent)}>
+                          {(model) => <option value={model.value}>{model.label}</option>}
+                        </For>
+                      </select>
+                      <span>{routeSaving()[agent.name] ? "保存中" : modelRouteLabel(agent)}</span>
+                      <A href={`/agents/${agent.name}`}>高级</A>
+                    </div>
+                  </div>
+                )}
+              </For>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <Show when={featured().length}>
+        <section class="agent-rail" aria-label="核心协作链路">
+          <For each={featured()}>
+            {(agent) => (
+              <A href={`/agents/${agent.name}`} class="agent-rail__item">
+                <span>{agent.mode === "primary" ? "主控" : "协作"}</span>
+                <strong>{agent.displayName ?? agent.name}</strong>
+                <small>{agent.description ?? "参与多智能体生产链路"}</small>
+              </A>
+            )}
+          </For>
+        </section>
+      </Show>
+
       <section class="agent-toolbar">
         <div>
-          <h1>智能体工作台</h1>
-          <p>{items().length} 个智能体，覆盖规划、研究、写作、审校与工程执行。</p>
+          <h2>智能体矩阵</h2>
+          <p>选择专业智能体进入配置，也可以从工作流直接生成协作会话。</p>
         </div>
         <div class="agent-toolbar__controls">
           <input
@@ -79,6 +545,59 @@ export default function AgentsPage() {
       <Show when={!loading() && filtered().length === 0}>
         <div class="agent-empty">未找到匹配的智能体。</div>
       </Show>
+
+      <section class="agent-inventory">
+        <div class="agent-inventory__column">
+          <div class="agent-section__header">
+            <div>
+              <h2>工具链</h2>
+              <p>这些工具会在智能体执行任务时被调度，不再藏在命令行里。</p>
+            </div>
+          </div>
+          <div class="agent-tool-groups">
+            <For each={grouped()}>
+              {(group) => (
+                <div class="agent-tool-group">
+                  <div class="agent-tool-group__bar">
+                    <span>{group.label}</span>
+                    <small>{group.items.length}</small>
+                  </div>
+                  <div class="agent-tool-list">
+                    <For each={group.items}>
+                      {(tool) => (
+                        <span class="agent-chip" title={tool.id}>
+                          {tool.label}
+                        </span>
+                      )}
+                    </For>
+                  </div>
+                </div>
+              )}
+            </For>
+          </div>
+        </div>
+        <div class="agent-inventory__column">
+          <div class="agent-section__header">
+            <div>
+              <h2>Skills</h2>
+              <p>按任务加载的专业流程、审核方法和工具使用规范。</p>
+            </div>
+          </div>
+          <div class="agent-skill-list">
+            <For each={visibleSkills()}>
+              {(skill) => (
+                <div class="agent-skill" title={skill.location}>
+                  <strong>{skill.name}</strong>
+                  <small>{skill.description}</small>
+                </div>
+              )}
+            </For>
+            <Show when={!skills().length && !loading()}>
+              <div class="agent-empty">当前未发现 Skills。</div>
+            </Show>
+          </div>
+        </div>
+      </section>
 
       <WorkflowGallery />
     </main>

--- a/packages/app/src/types/agent-studio.ts
+++ b/packages/app/src/types/agent-studio.ts
@@ -7,6 +7,7 @@ export type AgentModel = {
 
 export type AgentStudioItem = {
   name: string
+  displayName?: string
   description?: string
   mode: AgentMode
   native?: boolean
@@ -26,6 +27,18 @@ export type AgentStudioItem = {
 
 export type AgentStudioDetail = AgentStudioItem & {
   rawMarkdown: string
+}
+
+export type ToolInventoryItem = {
+  id: string
+  label: string
+  group: "agent" | "knowledge" | "survey" | "core" | "extension"
+}
+
+export type SkillInventoryItem = {
+  name: string
+  description: string
+  location: string
 }
 
 export type WorkflowRunArtifact = {

--- a/packages/app/src/utils/agent-card.ts
+++ b/packages/app/src/utils/agent-card.ts
@@ -1,7 +1,6 @@
 import type { AgentMode } from "@/types/agent-studio"
 
 export function modeLabel(mode: AgentMode) {
-  if (mode === "primary") return "主智能体"
-  if (mode === "subagent") return "子智能体"
-  return "通用"
+  if (mode === "primary") return "主控"
+  return "专业智能体"
 }

--- a/packages/desktop/e2e/01-startup.spec.ts
+++ b/packages/desktop/e2e/01-startup.spec.ts
@@ -2,7 +2,8 @@ import { expect, test } from "./helpers/app"
 import { state } from "./helpers/wait"
 
 test("启动后 sidecar 在 3s 内就绪", async ({ launchApp }) => {
-  const { page } = await launchApp("/dashboard")
+  const { page } = await launchApp("/agents")
 
   await state(page.locator("[data-testid=sidecar-status]"), "ready", 3000)
+  await expect(page.getByTestId("agents-page")).toBeVisible()
 })

--- a/packages/desktop/src-tauri/src/windows.rs
+++ b/packages/desktop/src-tauri/src/windows.rs
@@ -49,7 +49,7 @@ impl MainWindow {
             .unwrap_or(false);
         let decorations = use_decorations();
         let window_builder = base_window_config(
-            WebviewWindowBuilder::new(app, Self::LABEL, WebviewUrl::App("/#/dashboard".into())),
+            WebviewWindowBuilder::new(app, Self::LABEL, WebviewUrl::App("/#/agents".into())),
             app,
             decorations,
         )

--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -70,11 +70,13 @@ const WorkspaceDiffRoute = () => (
   </Suspense>
 )
 const DashboardRedirect = () => <Navigate href="/dashboard" />
+const AgentStudioRedirect = () => <Navigate href="/agents" />
 
 function ensureStandaloneLanding() {
-  if (location.hash === "#/dashboard") return
+  if (location.hash.startsWith("#/agents")) return
   if (location.hash.startsWith("#/workspace")) return
-  history.replaceState(null, "", `${location.pathname}${location.search}#/dashboard`)
+  if (/^#\/[^/]+\/session/.test(location.hash)) return
+  history.replaceState(null, "", `${location.pathname}${location.search}#/agents`)
 }
 
 // Create startup timer with performance budget and retry callback
@@ -696,7 +698,7 @@ render(() => {
               <Show when={!defaultServer.loading}>
                 <div class="railwise-app-shell" data-testid="app-shell">
                   <AppInterface
-                    defaultPath="/dashboard"
+                    defaultPath="/agents"
                     defaultServer={defaultServer.latest ?? ServerConnection.key(server)}
                     routes={
                       <>
@@ -705,7 +707,7 @@ render(() => {
                         <Route path="/workspace" component={WorkspaceRoute} />
                         <Route path="/workspace/diff" component={WorkspaceDiffRoute} />
                         <Route path="/workspace/*rest" component={WorkspaceRoute} />
-                        <Route path="*rest" component={DashboardRedirect} />
+                        <Route path="*rest" component={AgentStudioRedirect} />
                       </>
                     }
                     servers={[server]}

--- a/packages/railwise/src/server/routes/agent-studio.ts
+++ b/packages/railwise/src/server/routes/agent-studio.ts
@@ -13,6 +13,7 @@ import { Instance } from "../../project/instance"
 import { Session } from "../../session"
 import type { MessageV2 } from "../../session/message-v2"
 import { MessageTable, SessionTable } from "../../session/session.sql"
+import { Skill } from "../../skill"
 import { and, Database, eq, gte } from "../../storage/db"
 import {
   AdjustmentConditionTool,
@@ -70,6 +71,42 @@ const WorkflowRunArtifactSchema = z
     absoluteJsonPath: z.string(),
   })
   .meta({ ref: "WorkflowRunArtifact" })
+
+const AgentListItemSchema = Agent.Info.extend({
+  displayName: z.string().optional().meta({
+    description: "Localized product-facing name for Agent Studio.",
+  }),
+  filePath: z.string().optional().meta({
+    description: "Absolute path of the backing .md file.",
+  }),
+  callCount7d: z.number().int().optional().meta({
+    description: "Message count by this agent in the last 7 days.",
+  }),
+}).meta({ ref: "AgentListItem" })
+
+const AgentDetailSchema = Agent.Info.extend({
+  displayName: z.string().optional(),
+  filePath: z.string().optional(),
+  rawMarkdown: z.string().meta({
+    description: "Full markdown source including frontmatter.",
+  }),
+}).meta({ ref: "AgentDetail" })
+
+const ToolInventorySchema = z
+  .object({
+    id: z.string(),
+    label: z.string(),
+    group: z.enum(["agent", "knowledge", "survey", "core", "extension"]),
+  })
+  .meta({ ref: "ToolInventoryItem" })
+
+const SkillInventorySchema = z
+  .object({
+    name: z.string(),
+    description: z.string(),
+    location: z.string(),
+  })
+  .meta({ ref: "SkillInventoryItem" })
 
 const WorkflowRunSchema = z
   .object({
@@ -294,6 +331,172 @@ type FormatConverted = {
       equations: { name?: string; coefficients: Record<string, number>; observed: number; weight?: number }[]
     }
   }
+}
+
+const labels: Record<string, string> = {
+  task: "协作智能体调度",
+  skill: "Skill 加载器",
+  tool_wiki_query: "规范 Wiki 查询",
+  tool_wiki_ingest: "规范资料入库",
+  tool_wiki_index: "规范索引重建",
+  tool_wiki_lint: "规范库质检",
+  tool_norm_search: "规范条文检索",
+  tool_norm_diff: "规范版本对比",
+  tool_norm_cite: "规范引用固化",
+  tool_format_converter: "测量格式转换",
+  tool_adjustment_indirect: "间接平差",
+  tool_adjustment_free_network: "自由网平差",
+  tool_adjustment_robust: "稳健平差",
+  tool_variance_component: "方差分量估计",
+  tool_adjustment_condition: "条件平差",
+  tool_gross_error_detection: "粗差探测",
+  angle_convert_angle_convert: "角度格式转换",
+  angle_convert_decimal_to_dms: "十进制度转度分秒",
+  angle_convert_dms_to_decimal: "度分秒转十进制度",
+  axial_force_axial_force_calc: "支撑轴力换算",
+  axial_force_axial_force_comparison: "轴力多期对比",
+  chart_generator: "监测趋势图生成",
+  control_network_network_design: "控制网布设设计",
+  control_network_plane_network_adjustment: "平面控制网平差",
+  coord_transform_datum_transform: "坐标基准转换",
+  coord_transform_gauss_forward: "高斯正算",
+  coord_transform_gauss_inverse: "高斯反算",
+  cpiii_adjustment_cpiii_network_adjustment: "CPIII 控制网平差",
+  cpiii_adjustment_free_station_resection: "自由设站后方交会",
+  cross_section_clearance_check: "断面限界检查",
+  cross_section_convergence_calc: "隧道收敛计算",
+  cross_section_profile_comparison: "断面多期对比",
+  deformation_rate_deformation_comparison: "变形量多期对比",
+  deformation_rate_deformation_rate: "变形速率分析",
+  distance_calculator_atmospheric_correction: "气象改正",
+  distance_calculator_distance_reduction: "边长归算",
+  distance_calculator_projection_correction: "投影改正",
+  distance_calculator_slope_to_horizontal: "斜距转平距",
+  excel_export_excel_export: "Excel 成果表导出",
+  excel_export_monitoring_table_export: "监测数据表导出",
+  format_parser: "仪器原始格式解析",
+  inclinometer_inclinometer_profile: "测斜剖面分析",
+  inclinometer_inclinometer_trend: "测斜趋势分析",
+  monitoring_csv: "监测 CSV 清洗分析",
+  pile_stakeout_batch_stakeout_points: "放样点批量计算",
+  pile_stakeout_chainage_offset: "里程偏距计算",
+  pile_stakeout_polar_stakeout: "极坐标放样",
+  report_export: "Word 成果报告导出",
+  shield_guidance_shield_position: "盾构姿态计算",
+  shield_guidance_shield_ring_build: "管片拼装分析",
+  shield_guidance_shield_trend: "盾构趋势分析",
+  standard_query_list_standards: "规范库清单",
+  standard_query_query_standard: "规范条文查询",
+  survey_calculator_alert_level: "监测预警分级",
+  survey_calculator_leveling_adjustment: "水准网严密平差",
+  survey_calculator_leveling_closure: "水准闭合差检核",
+  survey_calculator_traverse_adjustment: "导线网严密平差",
+  survey_calculator_traverse_closure: "导线闭合差检核",
+  water_level_water_level_analysis: "地下水位分析",
+  water_level_water_level_contour: "地下水位等值线",
+}
+
+type ToolGroup = z.infer<typeof ToolInventorySchema>["group"]
+
+const railwiseAgents = [
+  ["chief_manager", "项目总控"],
+  ["solution_architect", "技术方案架构师"],
+  ["qa_inspector", "外业数据首检"],
+  ["data_analyst", "测绘数据分析"],
+  ["qa_reviewer", "总工办质检"],
+  ["technical_writer", "工程报告编制"],
+  ["commercial_specialist", "商务招投标"],
+  ["ppt_master", "汇报材料设计"],
+  ["cpiii_specialist", "CPIII 测量专家"],
+  ["adjustment_computer", "严密平差计算"],
+  ["railway_norm_consultant", "铁路规范顾问"],
+  ["norm_librarian", "规范资料管理员"],
+  ["knowledge_curator", "知识库整理员"],
+  ["source_ingestor", "资料入库专员"],
+] as const
+
+const railwiseAgentNames = new Map<string, string>(railwiseAgents)
+
+function displayName(agent: Agent.Info) {
+  return railwiseAgentNames.get(agent.name)
+}
+
+function business(agent: Agent.Info) {
+  return railwiseAgentNames.has(agent.name) && !agent.hidden
+}
+
+function rank(agent: Agent.Info) {
+  const index = railwiseAgents.findIndex(([name]) => name === agent.name)
+  return index < 0 ? railwiseAgents.length : index
+}
+
+function group(id: string): ToolGroup {
+  if (id === "task" || id === "skill") return "agent"
+  if (id.startsWith("tool_wiki_") || id.startsWith("tool_norm_") || id.startsWith("standard_query_")) {
+    return "knowledge"
+  }
+  if (
+    id.startsWith("tool_adjustment_") ||
+    id === "tool_format_converter" ||
+    id === "tool_gross_error_detection" ||
+    id === "tool_variance_component" ||
+    [
+      "angle_convert_",
+      "axial_force_",
+      "control_network_",
+      "coord_transform_",
+      "cpiii_adjustment_",
+      "cross_section_",
+      "deformation_rate_",
+      "distance_calculator_",
+      "excel_export_",
+      "inclinometer_",
+      "pile_stakeout_",
+      "shield_guidance_",
+      "survey_calculator_",
+      "water_level_",
+    ].some((prefix) => id.startsWith(prefix)) ||
+    ["chart_generator", "format_parser", "monitoring_csv", "report_export"].includes(id)
+  ) {
+    return "survey"
+  }
+  if (
+    [
+      "bash",
+      "read",
+      "glob",
+      "grep",
+      "edit",
+      "write",
+      "webfetch",
+      "websearch",
+      "codesearch",
+      "todowrite",
+      "question",
+      "apply_patch",
+    ].includes(id)
+  ) {
+    return "core"
+  }
+  return "extension"
+}
+
+function toolLabel(id: string) {
+  return labels[id] ?? id.replace(/^tool_/, "").replaceAll("_", " ")
+}
+
+async function inventory() {
+  const order: ToolGroup[] = ["agent", "knowledge", "survey", "core", "extension"]
+  return ToolRegistry.ids().then((ids) =>
+    ids
+      .filter((id) => id !== "invalid")
+      .map((id) => ({
+        id,
+        label: toolLabel(id),
+        group: group(id),
+      }))
+      .sort((a, b) => order.indexOf(a.group) - order.indexOf(b.group) || a.label.localeCompare(b.label)),
+  )
 }
 
 function file(name: string) {
@@ -1268,20 +1471,8 @@ async function archiveDelivery(input: { workflowId: string; sessionId: string })
 
 export const AgentStudioRoutes = lazy(() => {
   const schema = {
-    list: Agent.Info.extend({
-      filePath: z.string().optional().meta({
-        description: "Absolute path of the backing .md file.",
-      }),
-      callCount7d: z.number().int().optional().meta({
-        description: "Message count by this agent in the last 7 days.",
-      }),
-    }).meta({ ref: "AgentListItem" }),
-    detail: Agent.Info.extend({
-      filePath: z.string().optional(),
-      rawMarkdown: z.string().meta({
-        description: "Full markdown source including frontmatter.",
-      }),
-    }).meta({ ref: "AgentDetail" }),
+    list: AgentListItemSchema,
+    detail: AgentDetailSchema,
   }
 
   return new Hono()
@@ -1307,11 +1498,13 @@ export const AgentStudioRoutes = lazy(() => {
         const count = calls()
         const items = await Promise.all(
           agents
-            .filter((agent) => !agent.hidden)
+            .filter(business)
+            .sort((a, b) => rank(a) - rank(b) || a.name.localeCompare(b.name))
             .map(async (agent) => {
               const source = file(agent.name)
               return {
                 ...agent,
+                displayName: displayName(agent),
                 filePath: (await Bun.file(source).exists()) ? source : undefined,
                 callCount7d: count.get(agent.name) ?? 0,
               }
@@ -1319,6 +1512,53 @@ export const AgentStudioRoutes = lazy(() => {
         )
         return c.json(items)
       },
+    )
+    .get(
+      "/tool/list",
+      describeRoute({
+        summary: "List agent collaboration tools",
+        description: "Returns tools grouped for the Agent Studio capability inventory.",
+        operationId: "agentStudio.tool.list",
+        responses: {
+          200: {
+            description: "Tool inventory",
+            content: {
+              "application/json": {
+                schema: resolver(ToolInventorySchema.array()),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => c.json(await inventory()),
+    )
+    .get(
+      "/skill/list",
+      describeRoute({
+        summary: "List available skills",
+        description: "Returns skills discovered from workspace and global skill directories.",
+        operationId: "agentStudio.skill.list",
+        responses: {
+          200: {
+            description: "Skill inventory",
+            content: {
+              "application/json": {
+                schema: resolver(SkillInventorySchema.array()),
+              },
+            },
+          },
+        },
+      }),
+      async (c) =>
+        c.json(
+          (await Skill.all())
+            .map((skill) => ({
+              name: skill.name,
+              description: skill.description,
+              location: skill.location,
+            }))
+            .sort((a, b) => a.name.localeCompare(b.name)),
+        ),
     )
     .get(
       "/workflow/presets",
@@ -1547,6 +1787,7 @@ export const AgentStudioRoutes = lazy(() => {
         if (!agent) return c.json({ error: `agent "${name}" not found` }, 404)
         return c.json({
           ...agent,
+          displayName: displayName(agent),
           ...(await read(name, agent)),
         })
       },

--- a/packages/railwise/src/server/routes/agent-studio.ts
+++ b/packages/railwise/src/server/routes/agent-studio.ts
@@ -72,26 +72,6 @@ const WorkflowRunArtifactSchema = z
   })
   .meta({ ref: "WorkflowRunArtifact" })
 
-const AgentListItemSchema = Agent.Info.extend({
-  displayName: z.string().optional().meta({
-    description: "Localized product-facing name for Agent Studio.",
-  }),
-  filePath: z.string().optional().meta({
-    description: "Absolute path of the backing .md file.",
-  }),
-  callCount7d: z.number().int().optional().meta({
-    description: "Message count by this agent in the last 7 days.",
-  }),
-}).meta({ ref: "AgentListItem" })
-
-const AgentDetailSchema = Agent.Info.extend({
-  displayName: z.string().optional(),
-  filePath: z.string().optional(),
-  rawMarkdown: z.string().meta({
-    description: "Full markdown source including frontmatter.",
-  }),
-}).meta({ ref: "AgentDetail" })
-
 const ToolInventorySchema = z
   .object({
     id: z.string(),
@@ -1471,8 +1451,24 @@ async function archiveDelivery(input: { workflowId: string; sessionId: string })
 
 export const AgentStudioRoutes = lazy(() => {
   const schema = {
-    list: AgentListItemSchema,
-    detail: AgentDetailSchema,
+    list: Agent.Info.extend({
+      displayName: z.string().optional().meta({
+        description: "Localized product-facing name for Agent Studio.",
+      }),
+      filePath: z.string().optional().meta({
+        description: "Absolute path of the backing .md file.",
+      }),
+      callCount7d: z.number().int().optional().meta({
+        description: "Message count by this agent in the last 7 days.",
+      }),
+    }).meta({ ref: "AgentListItem" }),
+    detail: Agent.Info.extend({
+      displayName: z.string().optional(),
+      filePath: z.string().optional(),
+      rawMarkdown: z.string().meta({
+        description: "Full markdown source including frontmatter.",
+      }),
+    }).meta({ ref: "AgentDetail" }),
   }
 
   return new Hono()

--- a/packages/railwise/src/tool/registry.ts
+++ b/packages/railwise/src/tool/registry.ts
@@ -65,7 +65,11 @@ export namespace ToolRegistry {
     if (matches.length) await Config.waitForDependencies()
     for (const match of matches) {
       const namespace = path.basename(match, path.extname(match))
-      const mod = await import(match)
+      const mod = await import(match).catch((error) => {
+        log.warn("skipping custom tool that failed to load", { path: match, error })
+        return undefined
+      })
+      if (!mod) continue
       for (const [id, def] of Object.entries<ToolDefinition>(mod)) {
         custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))
       }

--- a/packages/railwise/test/server/agent-studio.test.ts
+++ b/packages/railwise/test/server/agent-studio.test.ts
@@ -83,6 +83,169 @@ async function writeAssistant(sessionID: string, parentID: string, text: string)
 }
 
 describe("server.routes.agent-studio", () => {
+  test("list shows Railwise business agents and hides base coding agents", async () => {
+    await using tmp = await tmpdir()
+    const home = process.env.RAILWISE_TEST_HOME
+    process.env.RAILWISE_TEST_HOME = tmp.path
+    try {
+      await mkdir(path.join(tmp.path, ".railwise", "agent"), { recursive: true })
+      await Bun.write(
+        path.join(tmp.path, ".railwise", "railwise.json"),
+        JSON.stringify({
+          version: "2.0",
+          system: { domain: "surveying_monitoring" },
+          tools: {
+            surveying: ["total_station", "gnss", "level"],
+            monitoring: ["settlement"],
+          },
+        }),
+      )
+      await Bun.write(
+        path.join(tmp.path, ".railwise", "agent", "chief_manager.md"),
+        "---\ndescription: 项目总控，负责任务拆解、智能体调度、流程控制与最终成果汇总\nmode: primary\n---\n业务主控。",
+      )
+      await Bun.write(
+        path.join(tmp.path, ".railwise", "agent", "qa_inspector.md"),
+        "---\ndescription: 外业数据首检员，负责原始测绘数据审查\nmode: subagent\n---\n外业质检。",
+      )
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const response = await AgentStudioRoutes().request("http://railwise.test/list")
+          const list = (await response.json()) as { name: string; description?: string; displayName?: string }[]
+          const names = list.map((agent) => agent.name)
+
+          expect(response.status).toBe(200)
+          expect(names).toContain("chief_manager")
+          expect(names).toContain("qa_inspector")
+          expect(list.find((agent) => agent.name === "chief_manager")?.displayName).toBe("项目总控")
+          expect(list.find((agent) => agent.name === "qa_inspector")?.displayName).toBe("外业数据首检")
+          expect(names).not.toContain("build")
+          expect(names).not.toContain("plan")
+          expect(names).not.toContain("general")
+          expect(names).not.toContain("explore")
+        },
+      })
+    } finally {
+      restore(home)
+    }
+  })
+
+  test("tool and skill inventory endpoints expose collaboration capabilities", async () => {
+    await using tmp = await tmpdir()
+    const home = process.env.RAILWISE_TEST_HOME
+    process.env.RAILWISE_TEST_HOME = tmp.path
+    try {
+      await mkdir(path.join(tmp.path, ".railwise", "skill", "review"), { recursive: true })
+      await Bun.write(
+        path.join(tmp.path, ".railwise", "skill", "review", "SKILL.md"),
+        "---\nname: railwise-review\ndescription: Review engineering delivery quality.\n---\n\nUse this skill for review.",
+      )
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const toolResponse = await AgentStudioRoutes().request("http://railwise.test/tool/list")
+          const skillResponse = await AgentStudioRoutes().request("http://railwise.test/skill/list")
+          const tools = (await toolResponse.json()) as { id: string; label: string; group: string }[]
+          const skills = (await skillResponse.json()) as { name: string; description: string; location: string }[]
+
+          expect(toolResponse.status).toBe(200)
+          expect(tools.some((tool) => tool.id === "task" && tool.group === "agent")).toBe(true)
+          expect(tools.some((tool) => tool.id === "skill" && tool.group === "agent")).toBe(true)
+          expect(skillResponse.status).toBe(200)
+          expect(skills.some((skill) => skill.name === "railwise-review")).toBe(true)
+        },
+      })
+    } finally {
+      restore(home)
+    }
+  })
+
+  test(
+    "tool inventory classifies Railwise production tools by professional domain",
+    async () => {
+      await using tmp = await tmpdir()
+      const home = process.env.RAILWISE_TEST_HOME
+      process.env.RAILWISE_TEST_HOME = tmp.path
+      try {
+        await mkdir(path.join(tmp.path, ".railwise", "tool"), { recursive: true })
+        await Bun.write(
+          path.join(tmp.path, ".railwise", "tool", "survey_calculator.ts"),
+          [
+            "export const leveling_closure = {",
+            "  description: '水准闭合差检核',",
+            "  args: {},",
+            "  execute: async () => 'ok',",
+            "}",
+            "",
+          ].join("\n"),
+        )
+        await Bun.write(
+          path.join(tmp.path, ".railwise", "tool", "standard_query.ts"),
+          [
+            "export const query_standard = {",
+            "  description: '规范条文查询',",
+            "  args: {},",
+            "  execute: async () => 'ok',",
+            "}",
+            "",
+          ].join("\n"),
+        )
+
+        await Instance.provide({
+          directory: tmp.path,
+          fn: async () => {
+            const response = await AgentStudioRoutes().request("http://railwise.test/tool/list")
+            const tools = (await response.json()) as { id: string; label: string; group: string }[]
+
+            expect(response.status).toBe(200)
+            expect(tools.find((tool) => tool.id === "survey_calculator_leveling_closure")).toMatchObject({
+              label: "水准闭合差检核",
+              group: "survey",
+            })
+            expect(tools.find((tool) => tool.id === "standard_query_query_standard")).toMatchObject({
+              label: "规范条文查询",
+              group: "knowledge",
+            })
+          },
+        })
+      } finally {
+        restore(home)
+      }
+    },
+    { timeout: 10_000 },
+  )
+
+  test(
+    "tool inventory keeps core tools when a local custom tool is broken",
+    async () => {
+      await using tmp = await tmpdir()
+      const home = process.env.RAILWISE_TEST_HOME
+      process.env.RAILWISE_TEST_HOME = tmp.path
+      try {
+        await mkdir(path.join(tmp.path, ".railwise", "tools"), { recursive: true })
+        await Bun.write(path.join(tmp.path, ".railwise", "tools", "broken.ts"), 'throw new Error("broken custom tool")\n')
+
+        await Instance.provide({
+          directory: tmp.path,
+          fn: async () => {
+            const response = await AgentStudioRoutes().request("http://railwise.test/tool/list")
+            const tools = (await response.json()) as { id: string; group: string }[]
+
+            expect(response.status).toBe(200)
+            expect(tools.some((tool) => tool.id === "task" && tool.group === "agent")).toBe(true)
+            expect(tools.some((tool) => tool.id === "read" && tool.group === "core")).toBe(true)
+          },
+        })
+      } finally {
+        restore(home)
+      }
+    },
+    { timeout: 10_000 },
+  )
+
   test("lists M8 wiki agents and CPIII workflow preset", async () => {
     await using tmp = await tmpdir()
     const home = process.env.RAILWISE_TEST_HOME


### PR DESCRIPTION
## Summary
- Restore the Agent Studio collaboration workspace onto dev, including business-agent filtering, model routing helpers, tool inventory, and skill inventory.
- Make the desktop app open Agent Studio by default instead of the old dashboard.
- Add/extend tests so the startup route and Agent Studio collaboration APIs stay covered.

## Verification
- bun test test/server/agent-studio.test.ts --timeout 30000
- bun test --preload ./happydom.ts ./src/pages/agents/collaboration.test.ts ./src/components/agent-card.test.tsx
- bun run typecheck in packages/railwise, packages/app, packages/desktop
- bun run build in packages/desktop
- bun run test:e2e -- 01-startup.spec.ts 04-agent-studio.spec.ts
- git push pre-push hook: bun turbo typecheck