### PR TITLE
fix(desktop): use standard windows sidecar

### DIFF
--- a/packages/desktop/scripts/utils.ts
+++ b/packages/desktop/scripts/utils.ts
@@ -13,7 +13,7 @@ export const SIDECAR_BINARIES: Array<{ rustTarget: string; ocBinary: string; ass
   },
   {
     rustTarget: "x86_64-pc-windows-msvc",
-    ocBinary: "railwise-windows-x64-baseline",
+    ocBinary: "railwise-windows-x64",
     assetExt: "zip",
   },
   {


### PR DESCRIPTION
## Summary
- Build the Windows desktop sidecar from the standard x64 CLI binary instead of the baseline variant.
- Avoid the Bun baseline runtime extraction failure seen in the desktop release workflow.

## Verification
- bun run typecheck in packages/desktop
- git push pre-push hook: bun turbo typecheck

Note: local cross-target Tauri check could not complete because this Mac does not have the x86_64-pc-windows-msvc Rust target installed; the GitHub Windows runner covers that path.