### PR TITLE
fix(desktop): release Windows beta as NSIS internal installer

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -205,7 +205,7 @@ jobs:
               args+=(--skip-stapling)
             fi
           fi
-          if [ "${{ matrix.platform }}" = "windows" ] && [ "$WINDOWS_UNSIGNED_INTERNAL" = "true" ]; then
+          if [ "${{ matrix.platform }}" = "windows" ]; then
             args+=(--bundles nsis)
           fi
           bun run --cwd packages/desktop tauri -- "${args[@]}"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -267,7 +267,6 @@ jobs:
     name: Create draft release
     runs-on: ubuntu-22.04
     needs: build
-    if: github.event_name != 'workflow_dispatch' || inputs.windows_unsigned_internal != true
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v8
@@ -294,6 +293,9 @@ jobs:
             case "$file" in
               */unsigned-railwise-desktop-windows/*)
                 continue
+                ;;
+              */railwise-desktop-windows-x64-internal-*/*.exe)
+                stage "$file" "RAILWISE_${VERSION}_windows_x64_internal_unsigned.exe"
                 ;;
               *aarch64-apple-darwin*/macos/*.dmg)
                 stage "$file" "RAILWISE_${VERSION}_macos_apple_silicon.dmg"


### PR DESCRIPTION
## Summary
- build Windows desktop releases as a single NSIS x64 installer
- include the internal unsigned Windows installer in draft desktop releases when `windows_unsigned_internal=true`
- avoid MSI/WiX code page 1252 failures with the Chinese product name

## Verification
- git diff --check
- actionlint .github/workflows/desktop-release.yml
- pre-push turbo typecheck
- Desktop Release run 25990942868 succeeded