### PR TITLE
Desktop Harness runtime v2

### DIFF
--- a/packages/app/src/pages/harness/index.tsx
+++ b/packages/app/src/pages/harness/index.tsx
@@ -1,5 +1,5 @@
 import "./harness.css"
-import { A } from "@solidjs/router"
+import { A, useSearchParams } from "@solidjs/router"
 import { createMemo, createResource } from "solid-js"
 import { HarnessPermissionCard } from "@/components/harness-permission-card"
 import { HarnessStatus } from "@/components/harness-status"
@@ -8,13 +8,33 @@ import { useGlobalSDK } from "@/context/global-sdk"
 
 export default function HarnessPage() {
   const sdk = useGlobalSDK()
-  const [status] = createResource(() =>
+  const [params] = useSearchParams()
+  const query = (value: string | string[] | undefined) => (Array.isArray(value) ? (value[0] ?? "") : (value ?? ""))
+  const sessionID = createMemo(() => query(params.sessionID) || query(params.session))
+  const [status, statusAction] = createResource(() =>
     sdk.client.harness
       .status()
       .then((result) => result.data)
       .catch(() => undefined),
   )
-  const events = createMemo<HarnessEvent[]>(() => [])
+  const [timeline, timelineAction] = createResource(sessionID, (id) =>
+    id
+      ? sdk.client.harness.session
+          .timeline({ sessionID: id })
+          .then((result) => result.data)
+          .catch(() => undefined)
+      : undefined,
+  )
+  const events = createMemo<HarnessEvent[]>(() => timeline()?.data ?? [])
+  const permission = createMemo(() => events().find((event) => event.type === "permission.requested"))
+  const permissionID = (event?: HarnessEvent) => event?.id.match(/^harness:(.+):requested$/)?.[1]
+  const reply = async (value: "once" | "reject") => {
+    const id = permissionID(permission())
+    if (!id) return
+    await sdk.client.permission.reply({ requestID: id, reply: value }).catch(() => undefined)
+    void statusAction.refetch()
+    void timelineAction.refetch()
+  }
 
   return (
     <main class="harness-page" data-testid="harness-page">
@@ -32,10 +52,17 @@ export default function HarnessPage() {
 
       <section class="harness-page__grid">
         <HarnessStatus status={status()} loading={status.loading} />
-        <HarnessPermissionCard event={events().find((event) => event.type === "permission.requested")} />
+        <HarnessPermissionCard event={permission()} onApprove={() => reply("once")} onReject={() => reply("reject")} />
       </section>
 
-      <HarnessTimeline events={events()} empty="打开资料目录并开始会话后，这里会显示 Harness 的实时运行轨迹。" />
+      <HarnessTimeline
+        events={events()}
+        empty={
+          sessionID()
+            ? "这个会话还没有可展示的 Harness 事件。"
+            : "打开资料目录并开始会话后，从会话入口进入这里会显示实时运行轨迹。"
+        }
+      />
     </main>
   )
 }

--- a/packages/app/src/pages/workbench/index.tsx
+++ b/packages/app/src/pages/workbench/index.tsx
@@ -1,8 +1,9 @@
 import "./workbench.css"
 import { A, useNavigate } from "@solidjs/router"
-import { createEffect, createMemo, createSignal, For, Show } from "solid-js"
+import { createEffect, createMemo, createResource, createSignal, For, Show } from "solid-js"
 import { useDialog } from "@railwise/ui/context/dialog"
 import { DialogSelectDirectory } from "@/components/dialog-select-directory"
+import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLayout } from "@/context/layout"
 import { usePlatform } from "@/context/platform"
@@ -26,11 +27,11 @@ const agents = [
   { value: "norm_librarian", label: "规范资料员", note: "规范条文、交付清单与引用" },
 ] as const
 
-const events = [
-  { title: "会话准备", detail: "选择资料目录后建立本地上下文", tone: "ready" },
-  { title: "能力调度", detail: "按任务加载智能体、Skills 与工具", tone: "idle" },
-  { title: "权限门禁", detail: "文件写入、命令执行前会明确请求确认", tone: "safe" },
-] as const
+const modeLabel = {
+  safe: "本地安全模式",
+  ask: "等待确认",
+  auto: "自动执行",
+} as const
 
 export default function WorkbenchPage() {
   const dialog = useDialog()
@@ -38,11 +39,18 @@ export default function WorkbenchPage() {
   const navigate = useNavigate()
   const platform = usePlatform()
   const server = useServer()
+  const sdk = useGlobalSDK()
   const sync = useGlobalSync()
   const [directory, setDirectory] = createSignal("")
   const [manual, setManual] = createSignal(false)
   const [agent, setAgent] = createSignal(defaultAgent)
   const [draft, setDraft] = createSignal("")
+  const [status] = createResource(directory, (value) =>
+    sdk.client.harness
+      .status(value ? { directory: value } : undefined)
+      .then((result) => result.data)
+      .catch(() => undefined),
+  )
 
   const recent = createMemo(() => recentWorkspaces(sync.data.project, 5))
   const hasWorkspace = createMemo(() => directory().trim().length > 0)
@@ -50,6 +58,22 @@ export default function WorkbenchPage() {
   const workspace = createMemo(() => compactPath({ value: directory(), home: sync.data.path.home }))
   const selected = createMemo(() => agents.find((item) => item.value === agent()) ?? agents[0])
   const canStart = createMemo(() => hasWorkspace() && hasPrompt())
+  const capability = createMemo(() =>
+    status()?.capabilityCount ? `${status()!.capabilityCount} 项已启用` : "基础能力加载中",
+  )
+  const permission = createMemo(() =>
+    status()?.pendingPermissionCount ? `${status()!.pendingPermissionCount} 个请求等待处理` : "当前没有危险权限请求",
+  )
+  const runtime = createMemo(() => [
+    { title: "会话准备", detail: hasWorkspace() ? workspace() : "选择资料目录后建立本地上下文", tone: "ready" },
+    { title: "能力调度", detail: capability(), tone: "idle" },
+    { title: "权限门禁", detail: permission(), tone: status()?.pendingPermissionCount ? "warn" : "safe" },
+    {
+      title: "工具执行",
+      detail: status()?.runningToolCount ? `${status()!.runningToolCount} 个工具正在运行` : "当前无运行工具",
+      tone: status()?.runningToolCount ? "ready" : "idle",
+    },
+  ])
 
   const updateDirectory = (value: string) => {
     setManual(true)
@@ -220,11 +244,11 @@ export default function WorkbenchPage() {
           <dl class="workbench-facts">
             <div>
               <dt>运行模式</dt>
-              <dd>本地安全模式</dd>
+              <dd>{status() ? modeLabel[status()!.mode] : "连接中"}</dd>
             </div>
             <div>
               <dt>当前模型</dt>
-              <dd>{defaultModel}</dd>
+              <dd>{status()?.model ?? defaultModel}</dd>
             </div>
             <div>
               <dt>工作区</dt>
@@ -232,13 +256,14 @@ export default function WorkbenchPage() {
             </div>
             <div>
               <dt>权限状态</dt>
-              <dd>当前没有危险权限请求</dd>
+              <dd>{permission()}</dd>
             </div>
           </dl>
         </section>
 
         <section>
           <h2>能力集</h2>
+          <p>{capability()}</p>
           <div class="workbench-capabilities">
             <span>主控智能体</span>
             <span>测绘资料检查</span>
@@ -250,7 +275,7 @@ export default function WorkbenchPage() {
         <section>
           <h2>运行轨迹</h2>
           <ol class="workbench-timeline">
-            <For each={events}>
+            <For each={runtime()}>
               {(event) => (
                 <li data-tone={event.tone}>
                   <strong>{event.title}</strong>

--- a/packages/app/src/pages/workbench/workbench.css
+++ b/packages/app/src/pages/workbench/workbench.css
@@ -337,6 +337,12 @@
   gap: 12px;
 }
 
+.workbench-context p {
+  margin: 0;
+  color: #667085;
+  font-size: 12px;
+}
+
 .workbench-facts {
   display: grid;
   gap: 8px;
@@ -413,6 +419,10 @@
 
 .workbench-timeline li[data-tone="safe"]::before {
   background: #12b76a;
+}
+
+.workbench-timeline li[data-tone="warn"]::before {
+  background: #f79009;
 }
 
 .workbench-timeline strong {

--- a/packages/railwise/src/harness/index.ts
+++ b/packages/railwise/src/harness/index.ts
@@ -1,1 +1,2 @@
 export * from "./schema"
+export * from "./service"

--- a/packages/railwise/src/harness/service.ts
+++ b/packages/railwise/src/harness/service.ts
@@ -1,0 +1,237 @@
+import { Marketplace } from "@/marketplace"
+import { PermissionNext } from "@/permission/next"
+import { Session } from "@/session"
+import type { MessageV2 } from "@/session/message-v2"
+import { HarnessEvent, HarnessStatus } from "./schema"
+
+export namespace Harness {
+  function text(value: unknown) {
+    if (value === undefined) return undefined
+    const str = typeof value === "string" ? value : JSON.stringify(value)
+    if (str.length <= 180) return str
+    return str.slice(0, 177) + "..."
+  }
+
+  function title(part: MessageV2.ToolPart) {
+    if (part.state.status === "running") return part.state.title ?? part.tool
+    if (part.state.status === "completed") return part.state.title || part.tool
+    return part.tool
+  }
+
+  function risk(name: string): HarnessEvent["risk"] {
+    if (["bash", "edit", "write", "patch"].some((item) => name.includes(item))) return "high"
+    if (["webfetch", "task", "skill"].some((item) => name.includes(item))) return "medium"
+    return "low"
+  }
+
+  function completed(part: MessageV2.ToolPart) {
+    if (part.state.status !== "completed" && part.state.status !== "error") return undefined
+    return Math.max(0, part.state.time.end - part.state.time.start)
+  }
+
+  function created(part: MessageV2.ToolPart, fallback: number) {
+    if (part.state.status === "pending") return fallback
+    return part.state.time.start
+  }
+
+  function tool(part: MessageV2.ToolPart, fallback: number): HarnessEvent {
+    const base = {
+      id: `harness:${part.id}:${part.state.status}`,
+      sessionID: part.sessionID,
+      createdAt: created(part, fallback),
+      risk: risk(part.tool),
+      capabilityID: `tool:${part.tool}`,
+      duration: completed(part),
+    }
+    if (part.state.status === "pending")
+      return HarnessEvent.parse({
+        ...base,
+        type: "tool.requested",
+        title: `准备调用工具：${part.tool}`,
+        detail: text(part.state.input),
+      })
+    if (part.state.status === "running")
+      return HarnessEvent.parse({
+        ...base,
+        type: "tool.started",
+        title: `正在执行：${title(part)}`,
+        detail: text(part.state.input),
+      })
+    if (part.state.status === "completed")
+      return HarnessEvent.parse({
+        ...base,
+        type: "tool.completed",
+        title: `工具完成：${title(part)}`,
+        detail: text(part.state.output),
+      })
+    return HarnessEvent.parse({
+      ...base,
+      type: "tool.failed",
+      title: `工具失败：${part.tool}`,
+      detail: text(part.state.input),
+      error: part.state.error,
+    })
+  }
+
+  function model(info: MessageV2.Assistant) {
+    return `${info.providerID}/${info.modelID}`
+  }
+
+  async function permissions() {
+    return PermissionNext.list().catch(() => [])
+  }
+
+  async function latest() {
+    try {
+      return Array.from(Session.list({ limit: 1 }))[0]
+    } catch {
+      return undefined
+    }
+  }
+
+  export async function status(input?: { sessionID?: string }) {
+    const session = input?.sessionID ? await Session.get(input.sessionID).catch(() => undefined) : await latest()
+    const messages = session ? await Session.messages({ sessionID: session.id }).catch(() => []) : []
+    const assistant = messages
+      .map((item) => item.info)
+      .filter((item): item is MessageV2.Assistant => item.role === "assistant")
+      .at(-1)
+    const running = messages
+      .flatMap((item) => item.parts)
+      .filter((part): part is MessageV2.ToolPart => part.type === "tool")
+      .filter((part) => part.state.status === "running").length
+    const pending = await permissions()
+
+    return HarnessStatus.parse({
+      mode: pending.length > 0 ? "ask" : "safe",
+      workspace: session?.directory,
+      model: assistant ? model(assistant) : undefined,
+      activeAgent: assistant?.agent,
+      capabilityCount: Marketplace.list().filter((item) => item.enabled).length,
+      pendingPermissionCount: pending.length,
+      runningToolCount: running,
+    })
+  }
+
+  export async function timeline(input: { sessionID: string }) {
+    const session = await Session.get(input.sessionID)
+    const messages = await Session.messages({ sessionID: input.sessionID })
+    const agents = new Set<string>()
+    const models = new Set<string>()
+    const events: HarnessEvent[] = [
+      HarnessEvent.parse({
+        id: `harness:${session.id}:started`,
+        sessionID: session.id,
+        type: "session.started",
+        title: "会话开始",
+        detail: session.title,
+        createdAt: session.time.created,
+        risk: "low",
+      }),
+    ]
+
+    for (const item of messages) {
+      if (item.info.role === "assistant") {
+        if (!agents.has(item.info.agent)) {
+          agents.add(item.info.agent)
+          events.push(
+            HarnessEvent.parse({
+              id: `harness:${item.info.id}:agent`,
+              sessionID: item.info.sessionID,
+              type: "agent.selected",
+              title: `智能体：${item.info.agent}`,
+              createdAt: item.info.time.created,
+              risk: "low",
+            }),
+          )
+        }
+        if (!models.has(model(item.info))) {
+          models.add(model(item.info))
+          events.push(
+            HarnessEvent.parse({
+              id: `harness:${item.info.id}:model`,
+              sessionID: item.info.sessionID,
+              type: "model.selected",
+              title: `模型：${model(item.info)}`,
+              createdAt: item.info.time.created,
+              risk: "low",
+            }),
+          )
+        }
+      }
+
+      events.push(
+        ...item.parts.flatMap((part) => {
+          if (part.type === "tool") return [tool(part, item.info.time.created)]
+          if (part.type === "subtask")
+            return [
+              HarnessEvent.parse({
+                id: `harness:${part.id}:agent`,
+                sessionID: part.sessionID,
+                type: "agent.selected",
+                title: `调用子智能体：${part.agent}`,
+                detail: part.description,
+                createdAt: item.info.time.created,
+                risk: "medium",
+              }),
+            ]
+          if (part.type === "patch")
+            return [
+              HarnessEvent.parse({
+                id: `harness:${part.id}:artifact`,
+                sessionID: part.sessionID,
+                type: "artifact.created",
+                title: "生成代码变更",
+                detail: `${part.files.length} 个文件`,
+                artifactPath: part.files[0],
+                createdAt: item.info.time.created,
+                risk: "medium",
+              }),
+            ]
+          return []
+        }),
+      )
+
+      if (item.info.role === "assistant" && item.info.time.completed) {
+        events.push(
+          HarnessEvent.parse({
+            id: `harness:${item.info.id}:completed`,
+            sessionID: item.info.sessionID,
+            type: "session.completed",
+            title: "本轮回复完成",
+            createdAt: item.info.time.completed,
+            duration: Math.max(0, item.info.time.completed - item.info.time.created),
+            risk: "low",
+          }),
+        )
+      }
+    }
+
+    events.push(
+      ...(await permissions())
+        .filter((item) => item.sessionID === input.sessionID)
+        .map((item) =>
+          HarnessEvent.parse({
+            id: `harness:${item.id}:requested`,
+            sessionID: item.sessionID,
+            type: "permission.requested",
+            title: `等待权限：${item.permission}`,
+            detail: text(item.patterns),
+            createdAt: Date.now(),
+            risk: risk(item.permission),
+            capabilityID: `permission:${item.permission}`,
+          }),
+        ),
+    )
+
+    return events.sort((a, b) => a.createdAt - b.createdAt)
+  }
+
+  export async function resolvePermission(input: { permissionID: string }) {
+    await PermissionNext.reply({
+      requestID: input.permissionID,
+      reply: "once",
+    })
+    return true
+  }
+}

--- a/packages/railwise/src/server/routes/harness.ts
+++ b/packages/railwise/src/server/routes/harness.ts
@@ -1,8 +1,7 @@
 import { Hono } from "hono"
 import { describeRoute, resolver, validator } from "hono-openapi"
 import z from "zod"
-import { HarnessEvent, HarnessStatus } from "../../harness"
-import { Marketplace } from "../../marketplace"
+import { Harness, HarnessEvent, HarnessStatus } from "../../harness"
 import { lazy } from "../../util/lazy"
 import { errors } from "../error"
 
@@ -32,15 +31,7 @@ export const HarnessRoutes = lazy(() =>
           ...errors(500),
         },
       }),
-      async (c) =>
-        c.json(
-          HarnessStatus.parse({
-            mode: "safe",
-            capabilityCount: Marketplace.list().filter((item) => item.enabled).length,
-            pendingPermissionCount: 0,
-            runningToolCount: 0,
-          }),
-        ),
+      async (c) => c.json(await Harness.status()),
     )
     .get(
       "/session/:sessionID/timeline",
@@ -61,7 +52,7 @@ export const HarnessRoutes = lazy(() =>
         },
       }),
       validator("param", z.object({ sessionID: z.string() })),
-      async (c) => c.json({ data: [] }),
+      async (c) => c.json({ data: await Harness.timeline(c.req.valid("param")) }),
     )
     .post(
       "/session/:sessionID/permission/:permissionID",
@@ -82,6 +73,6 @@ export const HarnessRoutes = lazy(() =>
         },
       }),
       validator("param", z.object({ sessionID: z.string(), permissionID: z.string() })),
-      async (c) => c.json(true),
+      async (c) => c.json(await Harness.resolvePermission(c.req.valid("param"))),
     ),
 )

--- a/packages/railwise/test/harness/service.test.ts
+++ b/packages/railwise/test/harness/service.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test"
+import { Harness } from "../../src/harness"
+import { Identifier } from "../../src/id/id"
+import { PermissionNext } from "../../src/permission/next"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import type { MessageV2 } from "../../src/session/message-v2"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+function assistant(input: { sessionID: string; parentID: string; time: number }): MessageV2.Assistant {
+  return {
+    id: Identifier.ascending("message"),
+    sessionID: input.sessionID,
+    role: "assistant",
+    time: {
+      created: input.time,
+      completed: input.time + 600,
+    },
+    parentID: input.parentID,
+    modelID: "deepseek-v4",
+    providerID: "deepseek",
+    mode: "build",
+    agent: "chief_manager",
+    path: {
+      cwd: ".",
+      root: ".",
+    },
+    cost: 0,
+    tokens: {
+      total: 0,
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: {
+        read: 0,
+        write: 0,
+      },
+    },
+    finish: "end_turn",
+  }
+}
+
+describe("Harness service", () => {
+  test("maps session messages into visible runtime events", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.createNext({
+          directory: tmp.path,
+          title: "复测资料检查",
+        })
+        const user = await Session.updateMessage({
+          id: Identifier.ascending("message"),
+          sessionID: session.id,
+          role: "user",
+          time: { created: session.time.created + 100 },
+          agent: "chief_manager",
+          model: {
+            providerID: "deepseek",
+            modelID: "deepseek-v4",
+          },
+        })
+        const reply = await Session.updateMessage(
+          assistant({
+            sessionID: session.id,
+            parentID: user.id,
+            time: session.time.created + 200,
+          }),
+        )
+        await Session.updatePart({
+          id: Identifier.ascending("part"),
+          sessionID: session.id,
+          messageID: reply.id,
+          type: "tool",
+          callID: "call_read",
+          tool: "read",
+          state: {
+            status: "completed",
+            input: { path: "CP3/成果表.xlsx" },
+            output: "读取完成",
+            title: "读取复测成果表",
+            metadata: {},
+            time: {
+              start: session.time.created + 300,
+              end: session.time.created + 700,
+            },
+          },
+        })
+        await Session.updatePart({
+          id: Identifier.ascending("part"),
+          sessionID: session.id,
+          messageID: reply.id,
+          type: "patch",
+          hash: "abc",
+          files: ["交付物清单.md"],
+        })
+
+        const events = await Harness.timeline({ sessionID: session.id })
+
+        expect(events.map((item) => item.type)).toEqual([
+          "session.started",
+          "agent.selected",
+          "model.selected",
+          "artifact.created",
+          "tool.completed",
+          "session.completed",
+        ])
+        expect(events.find((item) => item.type === "tool.completed")).toMatchObject({
+          title: "工具完成：读取复测成果表",
+          duration: 400,
+          risk: "low",
+        })
+        expect(events.find((item) => item.type === "artifact.created")?.artifactPath).toBe("交付物清单.md")
+      },
+    })
+  })
+
+  test("reports pending permissions in status and timeline", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.createNext({
+          directory: tmp.path,
+          title: "权限测试",
+        })
+        const ask = PermissionNext.ask({
+          id: Identifier.ascending("permission"),
+          sessionID: session.id,
+          permission: "bash",
+          patterns: ["rm -rf output"],
+          metadata: {},
+          always: [],
+          ruleset: [],
+        })
+
+        expect((await Harness.status({ sessionID: session.id })).pendingPermissionCount).toBe(1)
+        expect(await Harness.timeline({ sessionID: session.id })).toContainEqual(
+          expect.objectContaining({
+            type: "permission.requested",
+            title: "等待权限：bash",
+            risk: "high",
+          }),
+        )
+
+        const permission = (await PermissionNext.list())[0]
+        await Harness.resolvePermission({ permissionID: permission.id })
+        await expect(ask).resolves.toBeUndefined()
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Derive Harness status and session timelines from real Session, ToolPart, and PermissionNext runtime data.
- Wire Harness routes to the runtime service instead of stubbed empty responses.
- Connect Workbench and Harness pages to live status/timeline data while keeping the UI simple.

## Test Plan
- bun test test/harness/service.test.ts test/server/harness.test.ts test/harness/schema.test.ts
- bun test --preload ./happydom.ts ./src/pages/workbench/workbench-state.test.ts ./src/components/harness-timeline.test.tsx
- bun run typecheck in packages/railwise
- bun run typecheck in packages/app
- bun test:e2e:local -- app/home.spec.ts
- Browser preview on http://127.0.0.1:56011/