### PR TITLE
Workbench recent session entrypoints

### DIFF
--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -6,6 +6,7 @@ test("home renders the Workbench entrypoints", async ({ page }) => {
   await expect(page.getByTestId("workbench-page")).toBeVisible()
   await expect(page.getByRole("heading", { name: "告诉 RAILWISE 你想完成什么" })).toBeVisible()
   await expect(page.getByRole("button", { name: "选择资料目录" })).toBeVisible()
+  await expect(page.getByText("会话产物")).toBeVisible()
   await expect(page.getByRole("link", { name: "能力市场" })).toBeVisible()
   await expect(page.getByRole("link", { name: "Harness" })).toBeVisible()
   await expect(page.getByRole("button", { name: "Open project" })).toHaveCount(0)

--- a/packages/app/src/pages/workbench/index.tsx
+++ b/packages/app/src/pages/workbench/index.tsx
@@ -1,5 +1,6 @@
 import "./workbench.css"
 import { A, useNavigate } from "@solidjs/router"
+import { base64Encode } from "@railwise/util/encode"
 import { createEffect, createMemo, createResource, createSignal, For, Show } from "solid-js"
 import { useDialog } from "@railwise/ui/context/dialog"
 import { DialogSelectDirectory } from "@/components/dialog-select-directory"
@@ -17,7 +18,9 @@ import {
   emptyPrompt,
   primaryActionLabel,
   promptExamples,
+  recentSessions,
   recentWorkspaces,
+  sessionTitle,
 } from "./workbench-state"
 
 const agents = [
@@ -32,6 +35,13 @@ const modeLabel = {
   ask: "等待确认",
   auto: "自动执行",
 } as const
+
+const time = new Intl.DateTimeFormat("zh-CN", {
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+})
 
 export default function WorkbenchPage() {
   const dialog = useDialog()
@@ -56,6 +66,8 @@ export default function WorkbenchPage() {
   const hasWorkspace = createMemo(() => directory().trim().length > 0)
   const hasPrompt = createMemo(() => draft().trim().length > 0)
   const workspace = createMemo(() => compactPath({ value: directory(), home: sync.data.path.home }))
+  const workspaceStore = createMemo(() => (hasWorkspace() ? sync.child(directory())[0] : undefined))
+  const sessions = createMemo(() => recentSessions(workspaceStore()?.session ?? []))
   const selected = createMemo(() => agents.find((item) => item.value === agent()) ?? agents[0])
   const canStart = createMemo(() => hasWorkspace() && hasPrompt())
   const capability = createMemo(() =>
@@ -114,6 +126,8 @@ export default function WorkbenchPage() {
     navigate(target.href)
   }
 
+  const sessionHref = (sessionID: string) => `/${base64Encode(directory())}/session/${sessionID}`
+
   const primary = async () => {
     if (!hasWorkspace()) {
       await chooseDirectory()
@@ -126,6 +140,12 @@ export default function WorkbenchPage() {
     if (manual() || directory()) return
     const current = server.projects.last() ?? recent()[0]?.worktree
     if (current) setDirectory(current)
+  })
+
+  createEffect(() => {
+    const current = directory()
+    if (!current) return
+    void sync.project.loadSessions(current)
   })
 
   return (
@@ -234,7 +254,24 @@ export default function WorkbenchPage() {
 
         <section class="workbench-results" aria-label="会话产物">
           <h2>会话产物</h2>
-          <p>开始会话后，文件检查、工具调用、报告草稿和风险提示会在这里持续更新。</p>
+          <Show
+            when={sessions().length > 0}
+            fallback={<p>开始会话后，最近任务、工具调用和 Harness 轨迹会出现在这里。</p>}
+          >
+            <ul class="workbench-sessions">
+              <For each={sessions()}>
+                {(session) => (
+                  <li>
+                    <A href={sessionHref(session.id)}>
+                      <strong>{sessionTitle(session)}</strong>
+                      <span>{time.format(session.time.updated ?? session.time.created)}</span>
+                    </A>
+                    <A href={`/harness?sessionID=${session.id}`}>Harness</A>
+                  </li>
+                )}
+              </For>
+            </ul>
+          </Show>
         </section>
       </section>
 

--- a/packages/app/src/pages/workbench/index.tsx
+++ b/packages/app/src/pages/workbench/index.tsx
@@ -266,7 +266,9 @@ export default function WorkbenchPage() {
                       <strong>{sessionTitle(session)}</strong>
                       <span>{time.format(session.time.updated ?? session.time.created)}</span>
                     </A>
-                    <A href={`/harness?sessionID=${session.id}`}>Harness</A>
+                    <A href={`/harness?sessionID=${session.id}`} aria-label={`查看 ${sessionTitle(session)} 的运行轨迹`}>
+                      轨迹
+                    </A>
                   </li>
                 )}
               </For>

--- a/packages/app/src/pages/workbench/workbench-state.test.ts
+++ b/packages/app/src/pages/workbench/workbench-state.test.ts
@@ -3,7 +3,9 @@ import {
   compactPath,
   emptyPrompt,
   primaryActionLabel,
+  recentSessions,
   recentWorkspaces,
+  sessionTitle,
   shouldShowZeroCounter,
 } from "./workbench-state"
 
@@ -32,5 +34,20 @@ describe("workbench state", () => {
         { worktree: "/", time: { created: 1, updated: 40 } },
       ]).map((project) => project.worktree),
     ).toEqual(["/tmp/b", "/tmp/a"])
+  })
+
+  test("shows recent root sessions without archived or child sessions", () => {
+    expect(
+      recentSessions([
+        { id: "old", title: "旧会话", time: { created: 1 } },
+        { id: "child", title: "子会话", parentID: "new", time: { created: 40 } },
+        { id: "archived", title: "归档", time: { created: 50, archived: 60 } },
+        { id: "new", title: "最新会话", time: { created: 10, updated: 70 } },
+      ]).map((session) => session.id),
+    ).toEqual(["new", "old"])
+  })
+
+  test("falls back to a concise session title", () => {
+    expect(sessionTitle({ title: "  " })).toBe("未命名会话")
   })
 })

--- a/packages/app/src/pages/workbench/workbench-state.ts
+++ b/packages/app/src/pages/workbench/workbench-state.ts
@@ -12,6 +12,17 @@ export type WorkspaceProject = {
   }
 }
 
+export type WorkspaceSession = {
+  id: string
+  title?: string
+  parentID?: string
+  time: {
+    created: number
+    updated?: number
+    archived?: number
+  }
+}
+
 export const defaultAgent = "chief_manager"
 export const defaultModel = "DeepSeek V4"
 
@@ -59,4 +70,15 @@ export function recentWorkspaces(projects: WorkspaceProject[], limit = 5) {
       return true
     })
     .slice(0, limit)
+}
+
+export function recentSessions(sessions: WorkspaceSession[], limit = 4) {
+  return sessions
+    .filter((session) => !session.parentID && !session.time.archived)
+    .sort((a, b) => (b.time.updated ?? b.time.created) - (a.time.updated ?? a.time.created))
+    .slice(0, limit)
+}
+
+export function sessionTitle(session: Pick<WorkspaceSession, "title">) {
+  return session.title?.trim() || "未命名会话"
 }

--- a/packages/app/src/pages/workbench/workbench.css
+++ b/packages/app/src/pages/workbench/workbench.css
@@ -325,6 +325,60 @@
   background: #f8fafc;
 }
 
+.workbench-sessions {
+  display: grid;
+  gap: 8px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.workbench-sessions li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.workbench-sessions a {
+  min-width: 0;
+  padding: 10px 11px;
+  border: 1px solid #d4dae4;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #29313d;
+  text-decoration: none;
+}
+
+.workbench-sessions a:hover {
+  border-color: #8aa7ff;
+  background: #f3f7ff;
+}
+
+.workbench-sessions strong,
+.workbench-sessions span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workbench-sessions strong {
+  font-size: 13px;
+}
+
+.workbench-sessions span {
+  margin-top: 3px;
+  color: #667085;
+  font-size: 12px;
+}
+
+.workbench-sessions li > a:last-child {
+  color: #155eef;
+  font-size: 12px;
+  font-weight: 700;
+}
+
 .workbench-context {
   display: flex;
   flex-direction: column;
@@ -469,6 +523,10 @@
 
   .workbench-prompts > div,
   .workbench-context {
+    grid-template-columns: 1fr;
+  }
+
+  .workbench-sessions li {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
- show recent root sessions in the Workbench session artifacts area
- link each session back into the chat page and its Harness timeline
- add recent-session state helpers plus unit and e2e coverage

## Verification
- cd packages/app && bun test --preload ./happydom.ts ./src/pages/workbench/workbench-state.test.ts
- cd packages/app && bun run typecheck
- cd packages/app && bun test:e2e:local -- app/home.spec.ts
- git push hook: bun turbo typecheck