### PR TITLE
feat(app): submit workbench task handoffs

### DIFF
--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../fixtures"
+import { seedProjects, sessionIDFromUrl } from "../actions"
 
 test("home renders the Workbench entrypoints", async ({ page }) => {
   await page.goto("/")
@@ -25,4 +26,35 @@ test("Workbench navigation opens capability pages", async ({ page }) => {
   await page.getByRole("link", { name: "Harness" }).click()
   await expect(page.getByTestId("harness-page")).toBeVisible()
   await expect(page.getByRole("heading", { name: "运行时控制台" })).toBeVisible()
+})
+
+test("Workbench starts a real submitted session from the task box", async ({ page, sdk, directory }) => {
+  test.setTimeout(120_000)
+  await seedProjects(page, { directory })
+  await page.goto("/")
+
+  const token = `E2E_OK_${Date.now()}`
+  await page
+    .getByPlaceholder("例如：检查当前线路复测资料，列出缺失文件并给出下一步执行计划。")
+    .fill(`Reply with exactly: ${token}`)
+  await page.getByRole("button", { name: "开始会话" }).click()
+  await expect(page).toHaveURL(/\/session\/[^/?#]+/, { timeout: 30_000 })
+
+  const sessionID = sessionIDFromUrl(page.url())
+  if (!sessionID) throw new Error(`Failed to parse session id from url: ${page.url()}`)
+
+  await expect
+    .poll(
+      async () => {
+        const messages = await sdk.session.messages({ sessionID, limit: 50 }).then((result) => result.data ?? [])
+        return messages
+          .filter((message) => message.info.role === "user")
+          .flatMap((message) => message.parts)
+          .filter((part) => part.type === "text")
+          .map((part) => part.text)
+          .join("\n")
+      },
+      { timeout: 30_000 },
+    )
+    .toContain(token)
 })

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -188,6 +188,9 @@ export function SessionComposerRegion(props: {
     if (prompt.dirty()) return
     prompt.set([{ type: "text", content: text, start: 0, end: text.length }], text.length)
     setApplied(key)
+    if (!handoff()?.autoSubmit) return
+    setSessionHandoff(key, { autoSubmit: false })
+    requestAnimationFrame(() => setSubmitRequest((value) => value + 1))
   })
 
   useTemplateDrawerShortcut(() => setTemplates(true))

--- a/packages/app/src/pages/session/handoff.ts
+++ b/packages/app/src/pages/session/handoff.ts
@@ -4,6 +4,7 @@ import type { WorkflowRunArtifact } from "@/types/agent-studio"
 export type HandoffSession = {
   prompt: string
   files: Record<string, SelectedLineRange | null>
+  autoSubmit?: boolean
   workflowId?: string
   workflowName?: string
   artifacts?: WorkflowRunArtifact[]

--- a/packages/app/src/pages/workbench/index.tsx
+++ b/packages/app/src/pages/workbench/index.tsx
@@ -122,7 +122,7 @@ export default function WorkbenchPage() {
     })
     layout.projects.open(target.directory)
     server.projects.touch(target.directory)
-    setSessionHandoff(target.key, { prompt: target.prompt })
+    setSessionHandoff(target.key, { prompt: target.prompt, autoSubmit: true })
     navigate(target.href)
   }
 


### PR DESCRIPTION
## Summary
- make Workbench task starts auto-submit the handoff prompt into a real session
- keep other handoff entrypoints opt-in by adding an explicit autoSubmit flag
- add e2e coverage that verifies the task box creates a submitted session and stores the user task message

## Verification
- bun test:e2e:local -- app/home.spec.ts (red before implementation, green after)
- bun run typecheck
- bun test --preload ./happydom.ts ./src/pages/workbench/workbench-state.test.ts
- git diff --check
- push hook: bun turbo typecheck