### PR TITLE
feat(app): add workbench resume entry

### DIFF
--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -28,7 +28,7 @@ test("Workbench navigation opens capability pages", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "运行时控制台" })).toBeVisible()
 })
 
-test("Workbench starts a real submitted session from the task box", async ({ page, sdk, directory }) => {
+test("Workbench starts and resumes a real submitted session from the task box", async ({ page, sdk, directory }) => {
   test.setTimeout(120_000)
   await seedProjects(page, { directory })
   await page.goto("/")
@@ -57,4 +57,10 @@ test("Workbench starts a real submitted session from the task box", async ({ pag
       { timeout: 30_000 },
     )
     .toContain(token)
+
+  await page.goto("/")
+  const resume = page.getByRole("link", { name: "继续会话" }).first()
+  await expect(resume).toBeVisible()
+  await resume.click()
+  await expect(page).toHaveURL(new RegExp(`/session/${sessionID}(?:[/?#]|$)`))
 })

--- a/packages/app/src/pages/workbench/index.tsx
+++ b/packages/app/src/pages/workbench/index.tsx
@@ -68,6 +68,7 @@ export default function WorkbenchPage() {
   const workspace = createMemo(() => compactPath({ value: directory(), home: sync.data.path.home }))
   const workspaceStore = createMemo(() => (hasWorkspace() ? sync.child(directory())[0] : undefined))
   const sessions = createMemo(() => recentSessions(workspaceStore()?.session ?? []))
+  const latest = createMemo(() => sessions()[0])
   const selected = createMemo(() => agents.find((item) => item.value === agent()) ?? agents[0])
   const canStart = createMemo(() => hasWorkspace() && hasPrompt())
   const capability = createMemo(() =>
@@ -258,6 +259,18 @@ export default function WorkbenchPage() {
             when={sessions().length > 0}
             fallback={<p>开始会话后，最近任务、工具调用和 Harness 轨迹会出现在这里。</p>}
           >
+            <Show when={latest()}>
+              {(session) => (
+                <div class="workbench-resume">
+                  <div>
+                    <span>继续上次会话</span>
+                    <strong>{sessionTitle(session())}</strong>
+                    <small>{time.format(session().time.updated ?? session().time.created)} 更新</small>
+                  </div>
+                  <A href={sessionHref(session().id)}>继续会话</A>
+                </div>
+              )}
+            </Show>
             <ul class="workbench-sessions">
               <For each={sessions()}>
                 {(session) => (

--- a/packages/app/src/pages/workbench/workbench.css
+++ b/packages/app/src/pages/workbench/workbench.css
@@ -325,6 +325,52 @@
   background: #f8fafc;
 }
 
+.workbench-resume {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 12px;
+  border: 1px solid #b8c7e8;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.workbench-resume div {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.workbench-resume span,
+.workbench-resume small {
+  color: #667085;
+  font-size: 12px;
+}
+
+.workbench-resume strong {
+  overflow: hidden;
+  color: #101828;
+  font-size: 14px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workbench-resume a {
+  flex: none;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: #155eef;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 720;
+  text-decoration: none;
+}
+
+.workbench-resume a:hover {
+  background: #0f4ed3;
+}
+
 .workbench-sessions {
   display: grid;
   gap: 8px;
@@ -528,6 +574,11 @@
 
   .workbench-sessions li {
     grid-template-columns: 1fr;
+  }
+
+  .workbench-resume {
+    align-items: stretch;
+    flex-direction: column;
   }
 
   .workbench-composer select {


### PR DESCRIPTION
## Summary
- add a prominent Workbench resume block for the latest session
- keep recent session list and Harness trace links below the primary resume action
- extend home e2e coverage to verify returning home can resume the created session

## Verification
- bun test:e2e:local -- app/home.spec.ts (red before implementation, green after)
- bun run typecheck
- bun test --preload ./happydom.ts ./src/pages/workbench/workbench-state.test.ts
- git diff --check
- push hook: bun turbo typecheck