### PR TITLE
feat(app): show workbench resume runtime status

### DIFF
--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -61,6 +61,7 @@ test("Workbench starts and resumes a real submitted session from the task box", 
   await page.goto("/")
   const resume = page.getByRole("link", { name: "继续会话" }).first()
   await expect(resume).toBeVisible()
+  await expect(page.getByText("可继续协作")).toBeVisible()
   await resume.click()
   await expect(page).toHaveURL(new RegExp(`/session/${sessionID}(?:[/?#]|$)`))
 })

--- a/packages/app/src/pages/workbench/index.tsx
+++ b/packages/app/src/pages/workbench/index.tsx
@@ -20,6 +20,7 @@ import {
   promptExamples,
   recentSessions,
   recentWorkspaces,
+  runtimeLabel,
   sessionTitle,
 } from "./workbench-state"
 
@@ -265,7 +266,9 @@ export default function WorkbenchPage() {
                   <div>
                     <span>继续上次会话</span>
                     <strong>{sessionTitle(session())}</strong>
-                    <small>{time.format(session().time.updated ?? session().time.created)} 更新</small>
+                    <small>
+                      {runtimeLabel(status())} · {time.format(session().time.updated ?? session().time.created)} 更新
+                    </small>
                   </div>
                   <A href={sessionHref(session().id)}>继续会话</A>
                 </div>

--- a/packages/app/src/pages/workbench/workbench-state.test.ts
+++ b/packages/app/src/pages/workbench/workbench-state.test.ts
@@ -5,6 +5,7 @@ import {
   primaryActionLabel,
   recentSessions,
   recentWorkspaces,
+  runtimeLabel,
   sessionTitle,
   shouldShowZeroCounter,
 } from "./workbench-state"
@@ -49,5 +50,11 @@ describe("workbench state", () => {
 
   test("falls back to a concise session title", () => {
     expect(sessionTitle({ title: "  " })).toBe("未命名会话")
+  })
+
+  test("summarizes runtime status for the resume card", () => {
+    expect(runtimeLabel({ pendingPermissionCount: 2, runningToolCount: 1 })).toBe("2 个权限等待确认")
+    expect(runtimeLabel({ runningToolCount: 3 })).toBe("3 个工具正在运行")
+    expect(runtimeLabel({})).toBe("可继续协作")
   })
 })

--- a/packages/app/src/pages/workbench/workbench-state.ts
+++ b/packages/app/src/pages/workbench/workbench-state.ts
@@ -23,6 +23,11 @@ export type WorkspaceSession = {
   }
 }
 
+export type WorkbenchRuntime = {
+  runningToolCount?: number
+  pendingPermissionCount?: number
+}
+
 export const defaultAgent = "chief_manager"
 export const defaultModel = "DeepSeek V4"
 
@@ -81,4 +86,10 @@ export function recentSessions(sessions: WorkspaceSession[], limit = 4) {
 
 export function sessionTitle(session: Pick<WorkspaceSession, "title">) {
   return session.title?.trim() || "未命名会话"
+}
+
+export function runtimeLabel(input?: WorkbenchRuntime) {
+  if (input?.pendingPermissionCount) return `${input.pendingPermissionCount} 个权限等待确认`
+  if (input?.runningToolCount) return `${input.runningToolCount} 个工具正在运行`
+  return "可继续协作"
 }


### PR DESCRIPTION
## Summary
- add a reusable workbench runtime label for permission/tool/session states
- show the latest session runtime state in the Workbench resume card
- extend home e2e coverage for the resume status line

## Verification
- bun test --preload ./happydom.ts ./src/pages/workbench/workbench-state.test.ts
- bun test:e2e:local -- app/home.spec.ts
- bun run typecheck
- browser preview on http://127.0.0.1:56011/home
- git diff --check origin/dev..HEAD