### PR TITLE
feat(app): add workbench permission action

### DIFF
--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -86,7 +86,7 @@ test("Workbench routes pending permission requests back to the active session", 
     await seedSessionPermission(sdk, {
       sessionID,
       permission: "bash",
-      patterns: [project.directory],
+      patterns: ["README.md"],
       description: "seed workbench permission action",
     })
 

--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "../fixtures"
-import { seedProjects, sessionIDFromUrl } from "../actions"
+import { seedProjects, seedSessionPermission, sessionIDFromUrl } from "../actions"
 
 test("home renders the Workbench entrypoints", async ({ page }) => {
   await page.goto("/")
@@ -64,5 +64,34 @@ test("Workbench starts and resumes a real submitted session from the task box", 
   await expect(page.locator(".workbench-resume")).toContainText("可继续协作")
   await expect(page.getByTestId("workbench-session-status").filter({ hasText: "可继续协作" })).toHaveCount(1)
   await resume.click()
+  await expect(page).toHaveURL(new RegExp(`/session/${sessionID}(?:[/?#]|$)`))
+})
+
+test("Workbench routes pending permission requests back to the active session", async ({ page, sdk, directory }) => {
+  test.setTimeout(120_000)
+  await seedProjects(page, { directory })
+  await page.goto("/")
+
+  await page
+    .getByPlaceholder("例如：检查当前线路复测资料，列出缺失文件并给出下一步执行计划。")
+    .fill("列出当前目录文件。")
+  await page.getByRole("button", { name: "开始会话" }).click()
+  await expect(page).toHaveURL(/\/session\/[^/?#]+/, { timeout: 30_000 })
+
+  const sessionID = sessionIDFromUrl(page.url())
+  if (!sessionID) throw new Error(`Failed to parse session id from url: ${page.url()}`)
+
+  await seedSessionPermission(sdk, {
+    sessionID,
+    permission: "bash",
+    patterns: [directory],
+    description: "seed workbench permission action",
+  })
+
+  await page.goto("/")
+  const action = page.getByRole("link", { name: "处理权限" }).first()
+  await expect(action).toBeVisible()
+  await expect(page.locator(".workbench-resume")).toContainText("1 个权限等待确认")
+  await action.click()
   await expect(page).toHaveURL(new RegExp(`/session/${sessionID}(?:[/?#]|$)`))
 })

--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "../fixtures"
 import { seedProjects, seedSessionPermission, sessionIDFromUrl } from "../actions"
+import { createSdk } from "../utils"
 
 test("home renders the Workbench entrypoints", async ({ page }) => {
   await page.goto("/")
@@ -67,31 +68,33 @@ test("Workbench starts and resumes a real submitted session from the task box", 
   await expect(page).toHaveURL(new RegExp(`/session/${sessionID}(?:[/?#]|$)`))
 })
 
-test("Workbench routes pending permission requests back to the active session", async ({ page, sdk, directory }) => {
+test("Workbench routes pending permission requests back to the active session", async ({ page, withProject }) => {
   test.setTimeout(120_000)
-  await seedProjects(page, { directory })
-  await page.goto("/")
+  await withProject(async (project) => {
+    const sdk = createSdk(project.directory)
+    await page.goto("/")
 
-  await page
-    .getByPlaceholder("例如：检查当前线路复测资料，列出缺失文件并给出下一步执行计划。")
-    .fill("列出当前目录文件。")
-  await page.getByRole("button", { name: "开始会话" }).click()
-  await expect(page).toHaveURL(/\/session\/[^/?#]+/, { timeout: 30_000 })
+    await page
+      .getByPlaceholder("例如：检查当前线路复测资料，列出缺失文件并给出下一步执行计划。")
+      .fill("列出当前目录文件。")
+    await page.getByRole("button", { name: "开始会话" }).click()
+    await expect(page).toHaveURL(/\/session\/[^/?#]+/, { timeout: 30_000 })
 
-  const sessionID = sessionIDFromUrl(page.url())
-  if (!sessionID) throw new Error(`Failed to parse session id from url: ${page.url()}`)
+    const sessionID = sessionIDFromUrl(page.url())
+    if (!sessionID) throw new Error(`Failed to parse session id from url: ${page.url()}`)
 
-  await seedSessionPermission(sdk, {
-    sessionID,
-    permission: "bash",
-    patterns: [directory],
-    description: "seed workbench permission action",
+    await seedSessionPermission(sdk, {
+      sessionID,
+      permission: "bash",
+      patterns: [project.directory],
+      description: "seed workbench permission action",
+    })
+
+    await page.goto("/")
+    const action = page.getByRole("link", { name: "处理权限" }).first()
+    await expect(action).toBeVisible()
+    await expect(page.locator(".workbench-resume")).toContainText("1 个权限等待确认")
+    await action.click()
+    await expect(page).toHaveURL(new RegExp(`/session/${sessionID}(?:[/?#]|$)`))
   })
-
-  await page.goto("/")
-  const action = page.getByRole("link", { name: "处理权限" }).first()
-  await expect(action).toBeVisible()
-  await expect(page.locator(".workbench-resume")).toContainText("1 个权限等待确认")
-  await action.click()
-  await expect(page).toHaveURL(new RegExp(`/session/${sessionID}(?:[/?#]|$)`))
 })

--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "../fixtures"
 import { seedProjects, seedSessionPermission, sessionIDFromUrl } from "../actions"
+import { base64Decode } from "@railwise/util/encode"
 import { createSdk } from "../utils"
 
 test("home renders the Workbench entrypoints", async ({ page }) => {
@@ -68,33 +69,32 @@ test("Workbench starts and resumes a real submitted session from the task box", 
   await expect(page).toHaveURL(new RegExp(`/session/${sessionID}(?:[/?#]|$)`))
 })
 
-test("Workbench routes pending permission requests back to the active session", async ({ page, withProject }) => {
+test("Workbench routes pending permission requests back to the active session", async ({ page, directory }) => {
   test.setTimeout(120_000)
-  await withProject(async (project) => {
-    const sdk = createSdk(project.directory)
-    await page.goto("/")
+  await seedProjects(page, { directory })
+  await page.goto("/")
 
-    await page
-      .getByPlaceholder("例如：检查当前线路复测资料，列出缺失文件并给出下一步执行计划。")
-      .fill("列出当前目录文件。")
-    await page.getByRole("button", { name: "开始会话" }).click()
-    await expect(page).toHaveURL(/\/session\/[^/?#]+/, { timeout: 30_000 })
+  await page
+    .getByPlaceholder("例如：检查当前线路复测资料，列出缺失文件并给出下一步执行计划。")
+    .fill("列出当前目录文件。")
+  await page.getByRole("button", { name: "开始会话" }).click()
+  await expect(page).toHaveURL(/\/session\/[^/?#]+/, { timeout: 30_000 })
 
-    const sessionID = sessionIDFromUrl(page.url())
-    if (!sessionID) throw new Error(`Failed to parse session id from url: ${page.url()}`)
+  const sessionID = sessionIDFromUrl(page.url())
+  if (!sessionID) throw new Error(`Failed to parse session id from url: ${page.url()}`)
+  const current = base64Decode(new URL(page.url()).pathname.split("/").filter(Boolean)[0] ?? "")
 
-    await seedSessionPermission(sdk, {
-      sessionID,
-      permission: "bash",
-      patterns: ["README.md"],
-      description: "seed workbench permission action",
-    })
-
-    await page.goto("/")
-    const action = page.getByRole("link", { name: "处理权限" }).first()
-    await expect(action).toBeVisible()
-    await expect(page.locator(".workbench-resume")).toContainText("1 个权限等待确认")
-    await action.click()
-    await expect(page).toHaveURL(new RegExp(`/session/${sessionID}(?:[/?#]|$)`))
+  await seedSessionPermission(createSdk(current), {
+    sessionID,
+    permission: "bash",
+    patterns: ["README.md"],
+    description: "seed workbench permission action",
   })
+
+  await page.goto("/")
+  const action = page.getByRole("link", { name: "处理权限" }).first()
+  await expect(action).toBeVisible()
+  await expect(page.locator(".workbench-resume")).toContainText("1 个权限等待确认")
+  await action.click()
+  await expect(page).toHaveURL(new RegExp(`/session/${sessionID}(?:[/?#]|$)`))
 })

--- a/packages/app/src/pages/workbench/index.tsx
+++ b/packages/app/src/pages/workbench/index.tsx
@@ -20,6 +20,7 @@ import {
   promptExamples,
   recentSessions,
   recentWorkspaces,
+  resumeActionLabel,
   runtimeLabel,
   sessionRuntimeLabel,
   sessionTitle,
@@ -271,7 +272,9 @@ export default function WorkbenchPage() {
                       {runtimeLabel(status())} · {time.format(session().time.updated ?? session().time.created)} 更新
                     </small>
                   </div>
-                  <A href={sessionHref(session().id)}>继续会话</A>
+                  <A href={sessionHref(session().id)} data-state={status()?.pendingPermissionCount ? "warn" : "ready"}>
+                    {resumeActionLabel(status())}
+                  </A>
                 </div>
               )}
             </Show>

--- a/packages/app/src/pages/workbench/index.tsx
+++ b/packages/app/src/pages/workbench/index.tsx
@@ -18,6 +18,7 @@ import {
   emptyPrompt,
   primaryActionLabel,
   promptExamples,
+  primarySessionID,
   recentSessions,
   recentWorkspaces,
   resumeActionLabel,
@@ -72,6 +73,11 @@ export default function WorkbenchPage() {
   const workspaceStore = createMemo(() => (hasWorkspace() ? sync.child(directory())[0] : undefined))
   const sessions = createMemo(() => recentSessions(workspaceStore()?.session ?? []))
   const latest = createMemo(() => sessions()[0])
+  const primarySession = createMemo(
+    () =>
+      sessions().find((session) => session.id === primarySessionID({ latestID: latest()?.id, runtime: status() })) ??
+      latest(),
+  )
   const selected = createMemo(() => agents.find((item) => item.value === agent()) ?? agents[0])
   const canStart = createMemo(() => hasWorkspace() && hasPrompt())
   const capability = createMemo(() =>
@@ -262,7 +268,7 @@ export default function WorkbenchPage() {
             when={sessions().length > 0}
             fallback={<p>开始会话后，最近任务、工具调用和 Harness 轨迹会出现在这里。</p>}
           >
-            <Show when={latest()}>
+            <Show when={primarySession()}>
               {(session) => (
                 <div class="workbench-resume">
                   <div>

--- a/packages/app/src/pages/workbench/workbench-state.test.ts
+++ b/packages/app/src/pages/workbench/workbench-state.test.ts
@@ -5,6 +5,7 @@ import {
   primaryActionLabel,
   recentSessions,
   recentWorkspaces,
+  resumeActionLabel,
   runtimeLabel,
   sessionRuntimeLabel,
   sessionTitle,
@@ -57,6 +58,12 @@ describe("workbench state", () => {
     expect(runtimeLabel({ pendingPermissionCount: 2, runningToolCount: 1 })).toBe("2 个权限等待确认")
     expect(runtimeLabel({ runningToolCount: 3 })).toBe("3 个工具正在运行")
     expect(runtimeLabel({})).toBe("可继续协作")
+  })
+
+  test("points the resume action at pending permissions", () => {
+    expect(resumeActionLabel({ pendingPermissionCount: 1 })).toBe("处理权限")
+    expect(resumeActionLabel({ runningToolCount: 1 })).toBe("继续会话")
+    expect(resumeActionLabel({})).toBe("继续会话")
   })
 
   test("only marks the latest session with live runtime status", () => {

--- a/packages/app/src/pages/workbench/workbench-state.test.ts
+++ b/packages/app/src/pages/workbench/workbench-state.test.ts
@@ -5,6 +5,7 @@ import {
   primaryActionLabel,
   recentSessions,
   recentWorkspaces,
+  primarySessionID,
   resumeActionLabel,
   runtimeLabel,
   sessionRuntimeLabel,
@@ -66,6 +67,11 @@ describe("workbench state", () => {
     expect(resumeActionLabel({})).toBe("继续会话")
   })
 
+  test("prefers the pending permission session for the primary resume target", () => {
+    expect(primarySessionID({ latestID: "new", runtime: { pendingSessionID: "blocked" } })).toBe("blocked")
+    expect(primarySessionID({ latestID: "new", runtime: {} })).toBe("new")
+  })
+
   test("only marks the latest session with live runtime status", () => {
     expect(
       sessionRuntimeLabel({
@@ -75,5 +81,12 @@ describe("workbench state", () => {
       }),
     ).toBe("1 个工具正在运行")
     expect(sessionRuntimeLabel({ sessionID: "old", latestID: "new", runtime: { runningToolCount: 1 } })).toBe("已保存")
+    expect(
+      sessionRuntimeLabel({
+        sessionID: "old",
+        latestID: "new",
+        runtime: { pendingPermissionCount: 1, pendingSessionID: "old" },
+      }),
+    ).toBe("1 个权限等待确认")
   })
 })

--- a/packages/app/src/pages/workbench/workbench-state.ts
+++ b/packages/app/src/pages/workbench/workbench-state.ts
@@ -26,6 +26,7 @@ export type WorkspaceSession = {
 export type WorkbenchRuntime = {
   runningToolCount?: number
   pendingPermissionCount?: number
+  pendingSessionID?: string
 }
 
 export type SessionRuntime = {
@@ -105,7 +106,14 @@ export function resumeActionLabel(input?: WorkbenchRuntime) {
   return "继续会话"
 }
 
+export function primarySessionID(input: { latestID?: string; runtime?: WorkbenchRuntime }) {
+  return input.runtime?.pendingSessionID ?? input.latestID
+}
+
 export function sessionRuntimeLabel(input: SessionRuntime) {
+  if (input.runtime?.pendingSessionID === input.sessionID) return runtimeLabel(input.runtime)
   if (input.sessionID !== input.latestID) return "已保存"
-  return runtimeLabel(input.runtime)
+  return runtimeLabel(
+    input.runtime?.pendingSessionID ? { runningToolCount: input.runtime.runningToolCount } : input.runtime,
+  )
 }

--- a/packages/app/src/pages/workbench/workbench-state.ts
+++ b/packages/app/src/pages/workbench/workbench-state.ts
@@ -100,6 +100,11 @@ export function runtimeLabel(input?: WorkbenchRuntime) {
   return "可继续协作"
 }
 
+export function resumeActionLabel(input?: WorkbenchRuntime) {
+  if (input?.pendingPermissionCount) return "处理权限"
+  return "继续会话"
+}
+
 export function sessionRuntimeLabel(input: SessionRuntime) {
   if (input.sessionID !== input.latestID) return "已保存"
   return runtimeLabel(input.runtime)

--- a/packages/app/src/pages/workbench/workbench.css
+++ b/packages/app/src/pages/workbench/workbench.css
@@ -371,6 +371,14 @@
   background: #0f4ed3;
 }
 
+.workbench-resume a[data-state="warn"] {
+  background: #b54708;
+}
+
+.workbench-resume a[data-state="warn"]:hover {
+  background: #93370d;
+}
+
 .workbench-sessions {
   display: grid;
   gap: 8px;

--- a/packages/railwise/src/harness/schema.ts
+++ b/packages/railwise/src/harness/schema.ts
@@ -39,6 +39,7 @@ export const HarnessStatus = z.object({
   activeAgent: z.string().optional(),
   capabilityCount: z.number().int(),
   pendingPermissionCount: z.number().int(),
+  pendingSessionID: z.string().optional(),
   runningToolCount: z.number().int(),
 })
 

--- a/packages/railwise/src/harness/service.ts
+++ b/packages/railwise/src/harness/service.ts
@@ -101,15 +101,27 @@ export namespace Harness {
       .filter((part): part is MessageV2.ToolPart => part.type === "tool")
       .filter((part) => part.state.status === "running").length
     const list = await permissions()
-    const pending = input?.directory || input?.sessionID ? list.filter((item) => item.sessionID === session?.id) : list
+    const matched = await Promise.all(
+      list.map(async (item) => ({
+        item,
+        session: await Session.get(item.sessionID).catch(() => undefined),
+      })),
+    )
+    const pending = input?.sessionID
+      ? matched.filter((entry) => entry.item.sessionID === input.sessionID).map((entry) => entry.item)
+      : input?.directory
+        ? matched.filter((entry) => entry.session?.directory === input.directory).map((entry) => entry.item)
+        : list
+    const pendingSession = matched.find((entry) => entry.item.id === pending[0]?.id)?.session
 
     return HarnessStatus.parse({
       mode: pending.length > 0 ? "ask" : "safe",
-      workspace: session?.directory,
+      workspace: session?.directory ?? pendingSession?.directory,
       model: assistant ? model(assistant) : undefined,
       activeAgent: assistant?.agent,
       capabilityCount: Marketplace.list().filter((item) => item.enabled).length,
       pendingPermissionCount: pending.length,
+      pendingSessionID: pending[0]?.sessionID,
       runningToolCount: running,
     })
   }

--- a/packages/railwise/src/harness/service.ts
+++ b/packages/railwise/src/harness/service.ts
@@ -81,16 +81,16 @@ export namespace Harness {
     return PermissionNext.list().catch(() => [])
   }
 
-  async function latest() {
+  async function latest(input?: { directory?: string }) {
     try {
-      return Array.from(Session.list({ limit: 1 }))[0]
+      return Array.from(Session.list({ directory: input?.directory, limit: 1 }))[0]
     } catch {
       return undefined
     }
   }
 
-  export async function status(input?: { sessionID?: string }) {
-    const session = input?.sessionID ? await Session.get(input.sessionID).catch(() => undefined) : await latest()
+  export async function status(input?: { directory?: string; sessionID?: string }) {
+    const session = input?.sessionID ? await Session.get(input.sessionID).catch(() => undefined) : await latest(input)
     const messages = session ? await Session.messages({ sessionID: session.id }).catch(() => []) : []
     const assistant = messages
       .map((item) => item.info)
@@ -100,7 +100,8 @@ export namespace Harness {
       .flatMap((item) => item.parts)
       .filter((part): part is MessageV2.ToolPart => part.type === "tool")
       .filter((part) => part.state.status === "running").length
-    const pending = await permissions()
+    const list = await permissions()
+    const pending = input?.directory || input?.sessionID ? list.filter((item) => item.sessionID === session?.id) : list
 
     return HarnessStatus.parse({
       mode: pending.length > 0 ? "ask" : "safe",

--- a/packages/railwise/src/server/routes/harness.ts
+++ b/packages/railwise/src/server/routes/harness.ts
@@ -31,7 +31,8 @@ export const HarnessRoutes = lazy(() =>
           ...errors(500),
         },
       }),
-      async (c) => c.json(await Harness.status()),
+      validator("query", z.object({ directory: z.string().optional() })),
+      async (c) => c.json(await Harness.status(c.req.valid("query"))),
     )
     .get(
       "/session/:sessionID/timeline",

--- a/packages/railwise/test/harness/service.test.ts
+++ b/packages/railwise/test/harness/service.test.ts
@@ -153,4 +153,50 @@ describe("Harness service", () => {
       },
     })
   })
+
+  test("scopes pending permissions to the requested workspace status", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const target = await Session.createNext({
+          directory: tmp.path,
+          title: "目标工作区",
+        })
+        const other = await Session.createNext({
+          directory: `${tmp.path}/other`,
+          title: "其他工作区",
+        })
+        const asks = [
+          PermissionNext.ask({
+            id: Identifier.ascending("permission"),
+            sessionID: target.id,
+            permission: "bash",
+            patterns: ["cat target"],
+            metadata: {},
+            always: [],
+            ruleset: [],
+          }),
+          PermissionNext.ask({
+            id: Identifier.ascending("permission"),
+            sessionID: other.id,
+            permission: "bash",
+            patterns: ["cat other"],
+            metadata: {},
+            always: [],
+            ruleset: [],
+          }),
+        ]
+
+        expect((await Harness.status()).pendingPermissionCount).toBe(2)
+        expect((await Harness.status({ directory: tmp.path })).pendingPermissionCount).toBe(1)
+        expect((await Harness.status({ sessionID: target.id })).pendingPermissionCount).toBe(1)
+
+        for (const permission of await PermissionNext.list()) {
+          await Harness.resolvePermission({ permissionID: permission.id })
+        }
+        await Promise.all(asks)
+      },
+    })
+  })
 })

--- a/packages/railwise/test/harness/service.test.ts
+++ b/packages/railwise/test/harness/service.test.ts
@@ -189,13 +189,55 @@ describe("Harness service", () => {
         ]
 
         expect((await Harness.status()).pendingPermissionCount).toBe(2)
-        expect((await Harness.status({ directory: tmp.path })).pendingPermissionCount).toBe(1)
-        expect((await Harness.status({ sessionID: target.id })).pendingPermissionCount).toBe(1)
+        expect(await Harness.status({ directory: tmp.path })).toMatchObject({
+          pendingPermissionCount: 1,
+          pendingSessionID: target.id,
+        })
+        expect(await Harness.status({ sessionID: target.id })).toMatchObject({
+          pendingPermissionCount: 1,
+          pendingSessionID: target.id,
+        })
 
         for (const permission of await PermissionNext.list()) {
           await Harness.resolvePermission({ permissionID: permission.id })
         }
         await Promise.all(asks)
+      },
+    })
+  })
+
+  test("reports pending permissions from the requested workspace even when another session is latest", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const blocked = await Session.createNext({
+          directory: tmp.path,
+          title: "等待权限",
+        })
+        const ask = PermissionNext.ask({
+          id: Identifier.ascending("permission"),
+          sessionID: blocked.id,
+          permission: "bash",
+          patterns: ["cat target"],
+          metadata: {},
+          always: [],
+          ruleset: [],
+        })
+        await Session.createNext({
+          directory: tmp.path,
+          title: "更新的普通会话",
+        })
+
+        expect(await Harness.status({ directory: tmp.path })).toMatchObject({
+          pendingPermissionCount: 1,
+          pendingSessionID: blocked.id,
+        })
+
+        for (const permission of await PermissionNext.list()) {
+          await Harness.resolvePermission({ permissionID: permission.id })
+        }
+        await ask
       },
     })
   })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4639,6 +4639,7 @@ export type HarnessStatusResponses = {
     activeAgent?: string
     capabilityCount: number
     pendingPermissionCount: number
+    pendingSessionID?: string
     runningToolCount: number
   }
 }


### PR DESCRIPTION
## Summary
- add a Workbench resume action label for pending permission requests
- show a dedicated warning-styled permission action on the resume card
- cover the permission resume flow with a real local E2E path

## Verification
- bun test --preload ./happydom.ts ./src/pages/workbench/workbench-state.test.ts
- bun test:e2e:local -- app/home.spec.ts
- bun run typecheck
- git diff --check
- local browser preview at http://127.0.0.1:56011/home