### PR TITLE
test(desktop): reinforce workbench-first shell

### DIFF
--- a/docs/dev/00-product-boundaries.md
+++ b/docs/dev/00-product-boundaries.md
@@ -121,8 +121,10 @@ Desktop 用户关心：
 
 **核心场景**:
 
-- 智能体协作中枢
-- Agent Studio 可视化编排
+- Workbench 首屏任务对话
+- Harness 规划、智能体路由、工具调用、产物和权限轨迹
+- Marketplace 能力市场，安装和启用智能体、工具、Skills、工作流、MCP、模型 Provider 和 Harness 配置
+- Agent Studio 高级配置
 - 数据工作台
 - 文件导入、预览、对比和发送到智能体
 - 工作流执行、验收和交付包导出
@@ -197,8 +199,8 @@ RAILWISE monorepo
 
 验收：
 
-- 默认落地页是 Desktop 工作台，不是 Web 调试页。
-- Agent Studio、Dashboard、Workspace、Session 形成完整闭环。
+- 默认落地页是 `/home` Workbench，不是 Web 调试页、旧 Dashboard 或高级配置页。
+- Workbench、Harness、Marketplace、Workspace、Session 形成完整闭环。
 - 用户能从文件导入到智能体分析，再到交付包导出。
 - 安装包、签名、公证、自动更新和崩溃恢复通过 GA 门禁。
 - Desktop 文案不要求用户理解 CLI。

--- a/docs/dev/06-m7-acceptance.md
+++ b/docs/dev/06-m7-acceptance.md
@@ -26,7 +26,7 @@
 - 埋点默认关闭，首次启动弹窗请求授权；关闭时清空本地事件队列。
 - 埋点本地队列落在 `sqlite:railwise.telemetry.db`，通过 Tauri SQL plugin 写入 `telemetry_events` 和 `telemetry_state`。
 - 崩溃上报通过 `RAILWISE_SENTRY_DSN` / Glitchtip DSN 启用；默认空值不上报。
-- 桌面端不再暴露旧项目驾驶舱 UI，默认进入 `/agents` 智能体协作中枢；旧 `/dashboard` 仅作为兼容入口重定向。
+- 桌面端不再暴露旧项目驾驶舱 UI，默认进入 `/home` Workbench；旧 `/dashboard` 仅作为兼容入口重定向，不能重新出现旧项目驾驶舱或零计数首屏。
 - `packages/desktop/scripts/sse-soak.ts` 将 `/event` 长连验收固化为命令，默认 30 分钟，支持 `--seconds`、`--minutes`、`--url` 和 `--heartbeat-timeout-ms`。
 - `scripts/verify-desktop-m7.ts` 将 M7 静态验收固化为命令，覆盖 E2E 清单、视觉基准、TTFUI、遥测隐私和文档交付。
 - `scripts/verify-desktop-acceptance.ts` 提供一条命令的 M7 回归验收，默认快检，`--full` 执行 30 分钟 SSE 长连。

--- a/packages/app/src/pages/workbench/index.tsx
+++ b/packages/app/src/pages/workbench/index.tsx
@@ -15,8 +15,10 @@ import { collaborationTarget } from "@/pages/agents/collaboration"
 import { setSessionHandoff } from "@/pages/session/handoff"
 import {
   compactPath,
+  capabilitySummary,
   defaultAgent,
   emptyPrompt,
+  enabledCapabilityNames,
   harnessModelLabel,
   modelLabel,
   primaryActionLabel,
@@ -70,6 +72,12 @@ export default function WorkbenchPage() {
       .then((result) => result.data)
       .catch(() => undefined),
   )
+  const [capabilities] = createResource(() =>
+    sdk.client.marketplace.capabilities
+      .list()
+      .then((result) => result.data?.data ?? [])
+      .catch(() => []),
+  )
 
   const recent = createMemo(() => recentWorkspaces(sync.data.project, 5))
   const hasWorkspace = createMemo(() => directory().trim().length > 0)
@@ -85,8 +93,12 @@ export default function WorkbenchPage() {
   )
   const selected = createMemo(() => agents.find((item) => item.value === agent()) ?? agents[0])
   const canStart = createMemo(() => hasWorkspace() && hasPrompt())
+  const enabledCapabilities = createMemo(() => enabledCapabilityNames(capabilities() ?? []))
   const capability = createMemo(() =>
-    status()?.capabilityCount ? `${status()!.capabilityCount} 项已启用` : "基础能力加载中",
+    capabilitySummary({
+      count: status()?.capabilityCount ?? enabledCapabilities().length,
+      loading: status.loading && capabilities.loading,
+    }),
   )
   const permission = createMemo(() =>
     status()?.pendingPermissionCount ? `${status()!.pendingPermissionCount} 个请求等待处理` : "当前没有危险权限请求",
@@ -378,10 +390,9 @@ export default function WorkbenchPage() {
           <h2>能力集</h2>
           <p>{capability()}</p>
           <div class="workbench-capabilities">
-            <span>主控智能体</span>
-            <span>测绘资料检查</span>
-            <span>规范引用</span>
-            <span>文件读取</span>
+            <Show when={enabledCapabilities().length > 0} fallback={<span>打开能力市场启用专业能力</span>}>
+              <For each={enabledCapabilities()}>{(item) => <span>{item}</span>}</For>
+            </Show>
           </div>
         </section>
 

--- a/packages/app/src/pages/workbench/index.tsx
+++ b/packages/app/src/pages/workbench/index.tsx
@@ -7,15 +7,18 @@ import { DialogSelectDirectory } from "@/components/dialog-select-directory"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLayout } from "@/context/layout"
+import { useModels, type ModelKey } from "@/context/models"
 import { usePlatform } from "@/context/platform"
 import { useServer } from "@/context/server"
+import { useProviders } from "@/hooks/use-providers"
 import { collaborationTarget } from "@/pages/agents/collaboration"
 import { setSessionHandoff } from "@/pages/session/handoff"
 import {
   compactPath,
   defaultAgent,
-  defaultModel,
   emptyPrompt,
+  harnessModelLabel,
+  modelLabel,
   primaryActionLabel,
   promptExamples,
   primarySessionID,
@@ -55,6 +58,8 @@ export default function WorkbenchPage() {
   const server = useServer()
   const sdk = useGlobalSDK()
   const sync = useGlobalSync()
+  const models = useModels()
+  const providers = useProviders()
   const [directory, setDirectory] = createSignal("")
   const [manual, setManual] = createSignal(false)
   const [agent, setAgent] = createSignal(defaultAgent)
@@ -85,6 +90,33 @@ export default function WorkbenchPage() {
   )
   const permission = createMemo(() =>
     status()?.pendingPermissionCount ? `${status()!.pendingPermissionCount} 个请求等待处理` : "当前没有危险权限请求",
+  )
+  const configuredModel = () => {
+    const value = sync.data.config.model
+    if (!value) return undefined
+    const [providerID, ...rest] = value.split("/")
+    const modelID = rest.join("/")
+    if (!providerID || !modelID) return undefined
+    return { providerID, modelID }
+  }
+  const providerDefaultModel = () =>
+    providers.connected().flatMap((provider) => {
+      const modelID = providers.default()[provider.id] ?? Object.values(provider.models)[0]?.id
+      return modelID ? [{ providerID: provider.id, modelID }] : []
+    })[0]
+  const currentModel = createMemo(() =>
+    [configuredModel(), ...models.recent.list(), providerDefaultModel()]
+      .filter((item): item is ModelKey => !!item)
+      .map(models.find)
+      .find(Boolean),
+  )
+  const currentModelLabel = createMemo(() => modelLabel(currentModel()))
+  const harnessModel = createMemo(() =>
+    harnessModelLabel({
+      active: !!status()?.pendingPermissionCount || !!status()?.runningToolCount,
+      fallback: currentModelLabel(),
+      statusModel: status()?.model,
+    }),
   )
   const runtime = createMemo(() => [
     { title: "会话准备", detail: hasWorkspace() ? workspace() : "选择资料目录后建立本地上下文", tone: "ready" },
@@ -213,8 +245,8 @@ export default function WorkbenchPage() {
             <h1>告诉 RAILWISE 你想完成什么</h1>
           </div>
           <div class="workbench-model">
-            <span>默认模型</span>
-            <strong>{defaultModel}</strong>
+            <span>将使用模型</span>
+            <strong>{currentModelLabel()}</strong>
           </div>
         </header>
 
@@ -328,8 +360,8 @@ export default function WorkbenchPage() {
               <dd>{status() ? modeLabel[status()!.mode] : "连接中"}</dd>
             </div>
             <div>
-              <dt>当前模型</dt>
-              <dd>{status()?.model ?? defaultModel}</dd>
+              <dt>模型</dt>
+              <dd>{harnessModel()}</dd>
             </div>
             <div>
               <dt>工作区</dt>

--- a/packages/app/src/pages/workbench/workbench-state.test.ts
+++ b/packages/app/src/pages/workbench/workbench-state.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test"
 import {
   compactPath,
   emptyPrompt,
+  harnessModelLabel,
+  modelLabel,
   primaryActionLabel,
   recentSessions,
   recentWorkspaces,
@@ -22,6 +24,19 @@ describe("workbench state", () => {
   test("uses chat-first primary actions", () => {
     expect(primaryActionLabel({ hasWorkspace: false })).toBe("选择资料目录")
     expect(primaryActionLabel({ hasWorkspace: true })).toBe("开始会话")
+  })
+
+  test("labels the model that will be used without stale session data", () => {
+    expect(modelLabel()).toBe("DeepSeek V4")
+    expect(modelLabel({ id: "deepseek-v4", name: "DeepSeek V4 (latest)", provider: { name: "DeepSeek" } })).toBe(
+      "DeepSeek / DeepSeek V4",
+    )
+    expect(harnessModelLabel({ fallback: "DeepSeek / DeepSeek V4", statusModel: "anthropic/claude", active: false })).toBe(
+      "DeepSeek / DeepSeek V4",
+    )
+    expect(harnessModelLabel({ fallback: "DeepSeek / DeepSeek V4", statusModel: "anthropic/claude", active: true })).toBe(
+      "anthropic/claude",
+    )
   })
 
   test("compacts home directory paths for recent workspaces", () => {

--- a/packages/app/src/pages/workbench/workbench-state.test.ts
+++ b/packages/app/src/pages/workbench/workbench-state.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test"
 import {
   compactPath,
+  capabilitySummary,
   emptyPrompt,
+  enabledCapabilityNames,
   harnessModelLabel,
   modelLabel,
   primaryActionLabel,
@@ -37,6 +39,20 @@ describe("workbench state", () => {
     expect(harnessModelLabel({ fallback: "DeepSeek / DeepSeek V4", statusModel: "anthropic/claude", active: true })).toBe(
       "anthropic/claude",
     )
+  })
+
+  test("summarizes enabled marketplace capabilities for the workbench", () => {
+    expect(
+      enabledCapabilityNames([
+        { name: "项目总控", enabled: true },
+        { name: " 本地工具桥接 ", enabled: true },
+        { name: "DeepSeek", enabled: false },
+      ]),
+    ).toEqual(["项目总控", "本地工具桥接"])
+    expect(enabledCapabilityNames([{ name: "A", enabled: true }], 0)).toEqual([])
+    expect(capabilitySummary({ loading: true })).toBe("正在加载能力集")
+    expect(capabilitySummary({ count: 3 })).toBe("3 项已启用")
+    expect(capabilitySummary({ count: 0 })).toBe("尚未启用能力")
   })
 
   test("compacts home directory paths for recent workspaces", () => {

--- a/packages/app/src/pages/workbench/workbench-state.ts
+++ b/packages/app/src/pages/workbench/workbench-state.ts
@@ -35,6 +35,14 @@ export type SessionRuntime = {
   runtime?: WorkbenchRuntime
 }
 
+export type WorkbenchModel = {
+  id?: string
+  name?: string
+  provider?: {
+    name?: string
+  }
+}
+
 export const defaultAgent = "chief_manager"
 export const defaultModel = "DeepSeek V4"
 
@@ -116,4 +124,17 @@ export function sessionRuntimeLabel(input: SessionRuntime) {
   return runtimeLabel(
     input.runtime?.pendingSessionID ? { runningToolCount: input.runtime.runningToolCount } : input.runtime,
   )
+}
+
+export function modelLabel(input?: WorkbenchModel) {
+  if (!input) return defaultModel
+  const model = input.name?.replace("(latest)", "").trim() || input.id
+  const provider = input.provider?.name?.trim()
+  if (provider && model) return `${provider} / ${model}`
+  return model ?? defaultModel
+}
+
+export function harnessModelLabel(input: { active?: boolean; fallback: string; statusModel?: string }) {
+  if (input.active && input.statusModel) return input.statusModel
+  return input.fallback
 }

--- a/packages/app/src/pages/workbench/workbench-state.ts
+++ b/packages/app/src/pages/workbench/workbench-state.ts
@@ -1,3 +1,5 @@
+import type { MarketplaceCapabilitiesResponse } from "@railwise/sdk/v2/client"
+
 export type WorkbenchAction = {
   hasWorkspace: boolean
   hasPrompt?: boolean
@@ -42,6 +44,8 @@ export type WorkbenchModel = {
     name?: string
   }
 }
+
+export type WorkbenchCapability = Pick<MarketplaceCapabilitiesResponse["data"][number], "enabled" | "name">
 
 export const defaultAgent = "chief_manager"
 export const defaultModel = "DeepSeek V4"
@@ -137,4 +141,18 @@ export function modelLabel(input?: WorkbenchModel) {
 export function harnessModelLabel(input: { active?: boolean; fallback: string; statusModel?: string }) {
   if (input.active && input.statusModel) return input.statusModel
   return input.fallback
+}
+
+export function enabledCapabilityNames(items: WorkbenchCapability[], limit = 8) {
+  return items
+    .filter((item) => item.enabled)
+    .map((item) => item.name.trim())
+    .filter(Boolean)
+    .slice(0, limit)
+}
+
+export function capabilitySummary(input: { count?: number; loading?: boolean }) {
+  if (input.loading) return "正在加载能力集"
+  if (input.count && input.count > 0) return `${input.count} 项已启用`
+  return "尚未启用能力"
 }

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -1,6 +1,6 @@
 # RAILWISE Desktop
 
-RAILWISE Desktop is the native engineering survey workstation for project dashboards, file review, visual Agent Studio workflows, and delivery package export.
+RAILWISE Desktop is the native engineering survey AI workbench. It opens to a focused task composer where users choose a local project folder, describe the engineering job, and let the RAILWISE Harness route agents, tools, skills, model providers, and permissions.
 
 It reuses RAILWISE Core through a local sidecar, but it is not positioned as a CLI wrapper. Desktop users should be able to complete the main workflow without knowing command-line commands.
 
@@ -50,11 +50,15 @@ bun run --cwd packages/desktop tauri build
 
 Desktop owns:
 
-- `/dashboard` project cockpit
+- `/home` Workbench-first task composer, project folder handoff, recent sessions, and Harness summary
+- `/harness` runtime console for planning, agent routing, tool calls, artifacts, and permission gates
+- `/marketplace` capability marketplace for agents, tools, Skills, workflows, MCP connectors, model providers, and Harness profiles
 - `/workspace` file import, preview, diff, and send-to-agent flows
-- `/agents` visual workflow orchestration
+- `/agents` advanced agent configuration for power users and debugging
 - delivery package review and export
 - native install, signing, notarization, crash recovery, and update UX
+
+`/dashboard` is a compatibility redirect and must not reintroduce the old project cockpit or zero-counter first screen.
 
 Desktop does not own CLI command design. CLI automation belongs in `packages/railwise/src/cli`.
 

--- a/packages/desktop/e2e/12-ttfui.spec.ts
+++ b/packages/desktop/e2e/12-ttfui.spec.ts
@@ -1,12 +1,14 @@
 import { expect, test } from "./helpers/app"
 
 test("即开即用：启动到可交互时间 < 15s", async ({ launchApp }) => {
-  const { page } = await launchApp("/agents")
+  const { page } = await launchApp("/home")
 
   const start = Date.now()
   await page.reload()
   await expect(page.locator("[data-testid=app-shell]")).toBeVisible({ timeout: 15000 })
-  await expect(page.locator("[data-testid=agents-page]")).toBeVisible({ timeout: 15000 })
+  await expect(page.locator("[data-testid=workbench-page]")).toBeVisible({ timeout: 15000 })
+  await expect(page.getByRole("heading", { name: "告诉 RAILWISE 你想完成什么" })).toBeVisible({ timeout: 15000 })
+  await expect(page.getByText("多智能体协作中枢")).toHaveCount(0)
   await expect(page.locator("[data-testid=sidecar-status]")).toHaveAttribute("data-state", "ready", { timeout: 15000 })
 
   const ttfui = Date.now() - start

--- a/packages/desktop/e2e/13-settings.spec.ts
+++ b/packages/desktop/e2e/13-settings.spec.ts
@@ -2,9 +2,9 @@ import { expect, test } from "./helpers/app"
 import { visible } from "./helpers/wait"
 
 test("设置中心：MCP、智能体、命令页展示真实数据", async ({ launchApp }) => {
-  const { page } = await launchApp("/agents")
+  const { page } = await launchApp("/home")
 
-  await visible(page.locator("[data-testid=agents-page]"))
+  await visible(page.locator("[data-testid=workbench-page]"))
   await page
     .getByLabel(/设置|Settings/)
     .first()

--- a/packages/desktop/e2e/14-workbench-navigation.spec.ts
+++ b/packages/desktop/e2e/14-workbench-navigation.spec.ts
@@ -4,6 +4,10 @@ test("Workbench 首屏可进入能力市场和 Harness", async ({ launchApp }) =
   const { page } = await launchApp("/home")
 
   await expect(page.getByTestId("workbench-page")).toBeVisible()
+  const capabilities = page.locator(".workbench-capabilities")
+  await expect(capabilities.getByText("项目总控")).toBeVisible()
+  await expect(capabilities.getByText("DeepSeek")).toHaveCount(0)
+
   await page.getByRole("link", { name: "能力市场" }).click()
   await expect(page.getByTestId("marketplace-page")).toBeVisible()
   await expect(page.getByRole("heading", { name: "能力市场" })).toBeVisible()

--- a/packages/desktop/e2e/14-workbench-navigation.spec.ts
+++ b/packages/desktop/e2e/14-workbench-navigation.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "./helpers/app"
+
+test("Workbench 首屏可进入能力市场和 Harness", async ({ launchApp }) => {
+  const { page } = await launchApp("/home")
+
+  await expect(page.getByTestId("workbench-page")).toBeVisible()
+  await page.getByRole("link", { name: "能力市场" }).click()
+  await expect(page.getByTestId("marketplace-page")).toBeVisible()
+  await expect(page.getByRole("heading", { name: "能力市场" })).toBeVisible()
+  await expect(page.getByText("项目总控")).toBeVisible()
+  await expect(page.getByText("DeepSeek")).toBeVisible()
+
+  await page.getByRole("link", { name: "返回工作台" }).click()
+  await expect(page.getByTestId("workbench-page")).toBeVisible()
+
+  await page.getByRole("link", { name: "Harness" }).click()
+  await expect(page.getByTestId("harness-page")).toBeVisible()
+  await expect(page.getByRole("heading", { name: "运行时控制台" })).toBeVisible()
+  await expect(page.getByText("本地安全模式")).toBeVisible()
+  await expect(page.getByText("5 项已启用")).toBeVisible()
+})

--- a/packages/desktop/e2e/15-workbench-session-start.spec.ts
+++ b/packages/desktop/e2e/15-workbench-session-start.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "./helpers/app"
+
+test("Workbench 可从资料目录和任务输入直接启动会话", async ({ launchApp }) => {
+  const prompt = "检查当前目录中的测量资料，列出缺失文件。"
+  const { page } = await launchApp("/home", { pickerPath: "/tmp/railwise-e2e/worktree" })
+
+  await expect(page.getByTestId("workbench-page")).toBeVisible()
+  await page.getByRole("button", { name: "选择资料目录" }).first().click()
+  await expect(page.getByText(/railwise-e2e\/worktree/)).toBeVisible()
+
+  await page.getByPlaceholder("例如：检查当前线路复测资料，列出缺失文件并给出下一步执行计划。").fill(prompt)
+  const submit = page.waitForRequest((request) => request.url().includes("/session/queue-e2e/prompt_async"))
+  await page.getByRole("button", { name: "开始会话" }).click()
+
+  await expect(page).toHaveURL(/\/session\/queue-e2e/)
+  expect((await submit).postData() ?? "").toContain(prompt)
+})

--- a/packages/desktop/e2e/helpers/app.ts
+++ b/packages/desktop/e2e/helpers/app.ts
@@ -251,6 +251,43 @@ const skills = [
   },
 ]
 
+const harness = {
+  mode: "safe",
+  workspace: "/tmp/railwise-e2e",
+  model: "deepseek/deepseek-v4",
+  activeAgent: "chief_manager",
+  capabilityCount: 5,
+  pendingPermissionCount: 0,
+  runningToolCount: 0,
+}
+
+const capabilities = [
+  {
+    id: "railwise.agent.chief_manager",
+    kind: "agent",
+    name: "项目总控",
+    description: "理解任务、拆解计划，并调度专业智能体执行。",
+    version: "0.1.0",
+    source: "builtin",
+    enabled: true,
+    installed: true,
+    permissions: { filesystem: "read", network: false, shell: false, external_directory: false, secrets: false },
+    tags: ["主控", "调度"],
+  },
+  {
+    id: "railwise.provider.deepseek",
+    kind: "provider",
+    name: "DeepSeek",
+    description: "默认推荐的中文工程任务模型提供方。",
+    version: "0.1.0",
+    source: "builtin",
+    enabled: false,
+    installed: true,
+    permissions: { filesystem: "none", network: true, shell: false, external_directory: false, secrets: true },
+    tags: ["模型", "推荐"],
+  },
+]
+
 export const test = base.extend<Fixtures>({
   launchApp: async ({ page, context }, use) => {
     await use(async (path = "/home", opts = {}) => {
@@ -300,6 +337,29 @@ async function setup(page: Page, opts: LaunchOptions) {
   await page.route(`${server}/project`, (route) => json(route, []))
   await page.route(`${server}/provider`, (route) => json(route, { all: [], default: {}, connected: [] }))
   await page.route(`${server}/provider/auth`, (route) => json(route, {}))
+  await page.route(`${server}/harness/status**`, (route) => json(route, harness))
+  await page.route(`${server}/harness/session/workflow-e2e/timeline`, (route) =>
+    json(route, {
+      data: [
+        {
+          id: "harness:workflow-e2e:started",
+          sessionID: "workflow-e2e",
+          type: "session.started",
+          title: "会话开始",
+          detail: "CPIII 规范查询与复测预案",
+          createdAt: 1_777_200_000_000,
+          risk: "low",
+        },
+      ],
+    }),
+  )
+  await page.route(`${server}/marketplace/capabilities`, (route) => json(route, { data: capabilities }))
+  await page.route(`${server}/marketplace/capabilities/*/enable`, (route) =>
+    json(route, { ...capabilities[0], enabled: true }),
+  )
+  await page.route(`${server}/marketplace/capabilities/*/disable`, (route) =>
+    json(route, { ...capabilities[0], enabled: false }),
+  )
   await page.route(`${server}/agent-studio/workflow/run`, (route) => {
     const input = route.request().postDataJSON() as { workflowId?: string }
     const item = input.workflowId === cpiii.id ? cpiii : workflow

--- a/packages/desktop/e2e/helpers/app.ts
+++ b/packages/desktop/e2e/helpers/app.ts
@@ -6,6 +6,7 @@ type WorkspaceFile = {
 }
 
 type LaunchOptions = {
+  pickerPath?: string
   workspaceFiles?: WorkspaceFile[]
 }
 
@@ -88,6 +89,13 @@ const session = {
   title: "工作流：CPIII 规范查询与复测预案",
   version: "v2",
   time: { created: 1_777_200_000_000, updated: 1_777_200_060_000 },
+}
+
+const queue = {
+  ...session,
+  id: "queue-e2e",
+  slug: "queue-e2e",
+  title: "检查当前目录中的测量资料",
 }
 
 const artifact = {
@@ -318,10 +326,16 @@ async function setup(page: Page, opts: LaunchOptions) {
   }
 
   await page.route(`${server}/global/health`, (route) => json(route, { healthy: true, version: "e2e" }))
+  const worktree = opts.pickerPath ?? "/tmp/railwise-e2e/worktree"
+
   await page.route(`${server}/global/event`, (route) =>
     route.fulfill({
       contentType: "text/event-stream",
-      body: 'event: message\ndata: {"directory":"global","payload":{"type":"server.connected","properties":{}}}\n\n',
+      body: [
+        'event: message\ndata: {"directory":"global","payload":{"type":"server.connected","properties":{}}}',
+        `event: message\ndata: ${JSON.stringify({ directory: worktree, payload: { type: "worktree.ready", properties: {} } })}`,
+        "",
+      ].join("\n\n"),
     }),
   )
   await page.route(`${server}/path`, (route) =>
@@ -470,6 +484,10 @@ async function setup(page: Page, opts: LaunchOptions) {
   await page.route(`${server}/mcp`, (route) => json(route, mcp))
   await page.route(`${server}/command`, (route) => json(route, commands))
   await page.route(`${server}/templates/list`, (route) => json(route, templates))
+  await page.route(`${server}/session/queue-e2e/message*`, (route) => json(route, []))
+  await page.route(`${server}/session/queue-e2e/todo*`, (route) => json(route, []))
+  await page.route(`${server}/session/queue-e2e/diff*`, (route) => json(route, []))
+  await page.route(`${server}/session/queue-e2e*`, (route) => json(route, queue))
   await page.route(`${server}/session/workflow-e2e/message*`, (route) => json(route, messages))
   await page.route(`${server}/session/workflow-e2e/todo*`, (route) => json(route, []))
   await page.route(`${server}/session/workflow-e2e/diff*`, (route) => json(route, []))
@@ -538,6 +556,7 @@ async function setup(page: Page, opts: LaunchOptions) {
           if (command === "convert_pptx_to_images") return []
           if (command === "convert_docx_to_html") return "<article>DOCX E2E</article>"
           if (command === "parse_markdown_command") return "<article>Markdown E2E</article>"
+          if (command === "plugin:dialog|open") return input.pickerPath
           if (command === "get_default_server_url") return null
           if (command === "get_wsl_config") return { enabled: false }
           if (command === "set_wsl_config") return null
@@ -575,7 +594,14 @@ async function setup(page: Page, opts: LaunchOptions) {
         )
       }
     },
-    { csv, dxf, server, workspace: opts.workspaceFiles ?? [], debug: process.env.RW_E2E_DEBUG === "1" },
+    {
+      csv,
+      dxf,
+      server,
+      pickerPath: opts.pickerPath ?? "/tmp/railwise-e2e/worktree",
+      workspace: opts.workspaceFiles ?? [],
+      debug: process.env.RW_E2E_DEBUG === "1",
+    },
   )
 }
 

--- a/packages/railwise/src/marketplace/service.ts
+++ b/packages/railwise/src/marketplace/service.ts
@@ -12,6 +12,16 @@ const State = z
   .catch({ enabled: {} })
 const file = path.join(Global.Path.state, "marketplace.json")
 const enabled = new Map<string, boolean>()
+const tools: Record<string, string> = {
+  bash: "railwise.mcp.local_tools",
+  edit: "railwise.mcp.local_tools",
+  write: "railwise.mcp.local_tools",
+  apply_patch: "railwise.mcp.local_tools",
+  read: "railwise.tool.file_reader",
+  glob: "railwise.tool.file_reader",
+  grep: "railwise.tool.file_reader",
+  skill: "railwise.skill.survey_review",
+}
 
 async function load() {
   return State.parse(await Bun.file(file).json().catch(() => ({})))
@@ -36,6 +46,20 @@ export namespace Marketplace {
 
   export function get(id: string) {
     return list().find((item) => item.id === id)
+  }
+
+  export function isEnabled(id: string) {
+    return get(id)?.enabled ?? false
+  }
+
+  export function toolEnabled(id: string) {
+    const capability = tools[id]
+    if (!capability) return true
+    return isEnabled(capability)
+  }
+
+  export function mcpEnabled() {
+    return isEnabled("railwise.mcp.local_tools")
   }
 
   async function save() {

--- a/packages/railwise/src/marketplace/service.ts
+++ b/packages/railwise/src/marketplace/service.ts
@@ -2,12 +2,35 @@ import { builtins as items } from "./builtin"
 import type { CapabilityManifest } from "./schema"
 
 export namespace Marketplace {
+  const enabled = new Map<string, boolean>()
+
+  function resolve(item: CapabilityManifest) {
+    const state = enabled.get(item.id)
+    if (state === undefined) return item
+    return { ...item, enabled: state }
+  }
+
   export function list() {
-    return items
+    return items.map(resolve)
   }
 
   export function builtins() {
-    return list()
+    return items
+  }
+
+  export function get(id: string) {
+    return list().find((item) => item.id === id)
+  }
+
+  export function setEnabled(id: string, state: boolean) {
+    const item = items.find((item) => item.id === id)
+    if (!item) return undefined
+    enabled.set(id, state)
+    return resolve(item)
+  }
+
+  export function reset() {
+    enabled.clear()
   }
 
   export function groups(list: CapabilityManifest[]) {

--- a/packages/railwise/src/marketplace/service.ts
+++ b/packages/railwise/src/marketplace/service.ts
@@ -1,9 +1,25 @@
+import { Global } from "@/global"
+import { Filesystem } from "@/util/filesystem"
+import path from "path"
+import z from "zod"
 import { builtins as items } from "./builtin"
 import type { CapabilityManifest } from "./schema"
 
-export namespace Marketplace {
-  const enabled = new Map<string, boolean>()
+const State = z
+  .object({
+    enabled: z.record(z.string(), z.boolean()).default({}),
+  })
+  .catch({ enabled: {} })
+const file = path.join(Global.Path.state, "marketplace.json")
+const enabled = new Map<string, boolean>()
 
+async function load() {
+  return State.parse(await Bun.file(file).json().catch(() => ({})))
+}
+
+for (const [id, state] of Object.entries((await load()).enabled)) enabled.set(id, state)
+
+export namespace Marketplace {
   function resolve(item: CapabilityManifest) {
     const state = enabled.get(item.id)
     if (state === undefined) return item
@@ -22,15 +38,26 @@ export namespace Marketplace {
     return list().find((item) => item.id === id)
   }
 
-  export function setEnabled(id: string, state: boolean) {
+  async function save() {
+    await Filesystem.writeJson(file, { enabled: Object.fromEntries(enabled) })
+  }
+
+  export async function reload() {
+    enabled.clear()
+    for (const [id, state] of Object.entries((await load()).enabled)) enabled.set(id, state)
+  }
+
+  export async function setEnabled(id: string, state: boolean) {
     const item = items.find((item) => item.id === id)
     if (!item) return undefined
     enabled.set(id, state)
+    await save()
     return resolve(item)
   }
 
-  export function reset() {
+  export async function reset() {
     enabled.clear()
+    await save()
   }
 
   export function groups(list: CapabilityManifest[]) {

--- a/packages/railwise/src/server/routes/marketplace.ts
+++ b/packages/railwise/src/server/routes/marketplace.ts
@@ -11,10 +11,6 @@ const CapabilitiesResponse = z
   })
   .meta({ ref: "MarketplaceCapabilitiesResponse" })
 
-function get(id: string) {
-  return Marketplace.list().find((item) => item.id === id)
-}
-
 export const MarketplaceRoutes = lazy(() =>
   new Hono()
     .get(
@@ -56,7 +52,7 @@ export const MarketplaceRoutes = lazy(() =>
       }),
       validator("param", z.object({ id: z.string() })),
       async (c) => {
-        const item = get(c.req.valid("param").id)
+        const item = Marketplace.get(c.req.valid("param").id)
         if (!item) return c.json({ error: "capability not found" }, 404)
         return c.json(item)
       },
@@ -80,9 +76,9 @@ export const MarketplaceRoutes = lazy(() =>
       }),
       validator("param", z.object({ id: z.string() })),
       async (c) => {
-        const item = get(c.req.valid("param").id)
+        const item = Marketplace.setEnabled(c.req.valid("param").id, true)
         if (!item) return c.json({ error: "capability not found" }, 404)
-        return c.json({ ...item, enabled: true })
+        return c.json(item)
       },
     )
     .post(
@@ -104,9 +100,9 @@ export const MarketplaceRoutes = lazy(() =>
       }),
       validator("param", z.object({ id: z.string() })),
       async (c) => {
-        const item = get(c.req.valid("param").id)
+        const item = Marketplace.setEnabled(c.req.valid("param").id, false)
         if (!item) return c.json({ error: "capability not found" }, 404)
-        return c.json({ ...item, enabled: false })
+        return c.json(item)
       },
     ),
 )

--- a/packages/railwise/src/server/routes/marketplace.ts
+++ b/packages/railwise/src/server/routes/marketplace.ts
@@ -76,7 +76,7 @@ export const MarketplaceRoutes = lazy(() =>
       }),
       validator("param", z.object({ id: z.string() })),
       async (c) => {
-        const item = Marketplace.setEnabled(c.req.valid("param").id, true)
+        const item = await Marketplace.setEnabled(c.req.valid("param").id, true)
         if (!item) return c.json({ error: "capability not found" }, 404)
         return c.json(item)
       },
@@ -100,7 +100,7 @@ export const MarketplaceRoutes = lazy(() =>
       }),
       validator("param", z.object({ id: z.string() })),
       async (c) => {
-        const item = Marketplace.setEnabled(c.req.valid("param").id, false)
+        const item = await Marketplace.setEnabled(c.req.valid("param").id, false)
         if (!item) return c.json({ error: "capability not found" }, 404)
         return c.json(item)
       },

--- a/packages/railwise/src/session/prompt.ts
+++ b/packages/railwise/src/session/prompt.ts
@@ -47,6 +47,7 @@ import { LLM } from "./llm"
 import { iife } from "@/util/iife"
 import { Shell } from "@/shell/shell"
 import { Truncate } from "@/tool/truncation"
+import { Marketplace } from "@/marketplace"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -833,7 +834,8 @@ export namespace SessionPrompt {
       })
     }
 
-    for (const [key, item] of Object.entries(await MCP.tools())) {
+    const mcp = Flag.RAILWISE_CLIENT === "desktop" && !Marketplace.mcpEnabled() ? {} : await MCP.tools()
+    for (const [key, item] of Object.entries(mcp)) {
       const execute = item.execute
       if (!execute) continue
 

--- a/packages/railwise/src/tool/registry.ts
+++ b/packages/railwise/src/tool/registry.ts
@@ -47,6 +47,7 @@ import {
   VarianceComponentTool,
 } from "./adjustment"
 import { FormatConverterTool } from "./format"
+import { Marketplace } from "@/marketplace"
 
 export namespace ToolRegistry {
   const log = Log.create({ service: "tool.registry" })
@@ -160,7 +161,7 @@ export namespace ToolRegistry {
       ...(config.experimental?.batch_tool === true ? [BatchTool] : []),
       ...(Flag.RAILWISE_EXPERIMENTAL_PLAN_MODE && Flag.RAILWISE_CLIENT === "cli" ? [PlanExitTool, PlanEnterTool] : []),
       ...custom,
-    ]
+    ].filter((tool) => Flag.RAILWISE_CLIENT !== "desktop" || Marketplace.toolEnabled(tool.id))
   }
 
   export async function ids() {

--- a/packages/railwise/test/marketplace/service.test.ts
+++ b/packages/railwise/test/marketplace/service.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import path from "path"
+import { Global } from "../../src/global"
 import { Marketplace } from "../../src/marketplace"
+import { Filesystem } from "../../src/util/filesystem"
 
-afterEach(() => Marketplace.reset())
+afterEach(async () => {
+  await Marketplace.reset()
+})
 
 describe("Marketplace service", () => {
   test("lists built-in RAILWISE capabilities with permission metadata", () => {
@@ -20,16 +25,28 @@ describe("Marketplace service", () => {
     expect(groups.map((group) => group.kind)).toContain("skill")
   })
 
-  test("keeps runtime enablement visible through list and get", () => {
-    const enabled = Marketplace.setEnabled("railwise.mcp.local_tools", true)
+  test("keeps runtime enablement visible through list and get", async () => {
+    const enabled = await Marketplace.setEnabled("railwise.mcp.local_tools", true)
 
     expect(enabled?.enabled).toBe(true)
     expect(Marketplace.get("railwise.mcp.local_tools")?.enabled).toBe(true)
     expect(Marketplace.list().find((item) => item.id === "railwise.mcp.local_tools")?.enabled).toBe(true)
 
-    const disabled = Marketplace.setEnabled("railwise.mcp.local_tools", false)
+    const disabled = await Marketplace.setEnabled("railwise.mcp.local_tools", false)
 
     expect(disabled?.enabled).toBe(false)
     expect(Marketplace.get("railwise.mcp.local_tools")?.enabled).toBe(false)
+  })
+
+  test("restores enablement from the local marketplace state file", async () => {
+    await Filesystem.writeJson(path.join(Global.Path.state, "marketplace.json"), {
+      enabled: {
+        "railwise.mcp.local_tools": true,
+      },
+    })
+
+    await Marketplace.reload()
+
+    expect(Marketplace.get("railwise.mcp.local_tools")?.enabled).toBe(true)
   })
 })

--- a/packages/railwise/test/marketplace/service.test.ts
+++ b/packages/railwise/test/marketplace/service.test.ts
@@ -38,6 +38,22 @@ describe("Marketplace service", () => {
     expect(Marketplace.get("railwise.mcp.local_tools")?.enabled).toBe(false)
   })
 
+  test("maps desktop tool access to marketplace capabilities", async () => {
+    expect(Marketplace.toolEnabled("read")).toBe(true)
+    expect(Marketplace.toolEnabled("bash")).toBe(false)
+    expect(Marketplace.mcpEnabled()).toBe(false)
+
+    await Marketplace.setEnabled("railwise.mcp.local_tools", true)
+
+    expect(Marketplace.toolEnabled("bash")).toBe(true)
+    expect(Marketplace.mcpEnabled()).toBe(true)
+
+    await Marketplace.setEnabled("railwise.tool.file_reader", false)
+
+    expect(Marketplace.toolEnabled("read")).toBe(false)
+    expect(Marketplace.toolEnabled("unknown_extension")).toBe(true)
+  })
+
   test("restores enablement from the local marketplace state file", async () => {
     await Filesystem.writeJson(path.join(Global.Path.state, "marketplace.json"), {
       enabled: {

--- a/packages/railwise/test/marketplace/service.test.ts
+++ b/packages/railwise/test/marketplace/service.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
 import { Marketplace } from "../../src/marketplace"
+
+afterEach(() => Marketplace.reset())
 
 describe("Marketplace service", () => {
   test("lists built-in RAILWISE capabilities with permission metadata", () => {
@@ -16,5 +18,18 @@ describe("Marketplace service", () => {
     expect(groups.map((group) => group.kind)).toContain("agent")
     expect(groups.map((group) => group.kind)).toContain("tool")
     expect(groups.map((group) => group.kind)).toContain("skill")
+  })
+
+  test("keeps runtime enablement visible through list and get", () => {
+    const enabled = Marketplace.setEnabled("railwise.mcp.local_tools", true)
+
+    expect(enabled?.enabled).toBe(true)
+    expect(Marketplace.get("railwise.mcp.local_tools")?.enabled).toBe(true)
+    expect(Marketplace.list().find((item) => item.id === "railwise.mcp.local_tools")?.enabled).toBe(true)
+
+    const disabled = Marketplace.setEnabled("railwise.mcp.local_tools", false)
+
+    expect(disabled?.enabled).toBe(false)
+    expect(Marketplace.get("railwise.mcp.local_tools")?.enabled).toBe(false)
   })
 })

--- a/packages/railwise/test/server/marketplace.test.ts
+++ b/packages/railwise/test/server/marketplace.test.ts
@@ -5,7 +5,9 @@ import { Log } from "../../src/util/log"
 
 Log.init({ print: false })
 
-afterEach(() => Marketplace.reset())
+afterEach(async () => {
+  await Marketplace.reset()
+})
 
 describe("server.routes.marketplace", () => {
   test("returns built-in capabilities", async () => {

--- a/packages/railwise/test/server/marketplace.test.ts
+++ b/packages/railwise/test/server/marketplace.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
+import { Marketplace } from "../../src/marketplace"
 import { Server } from "../../src/server/server"
 import { Log } from "../../src/util/log"
 
 Log.init({ print: false })
+
+afterEach(() => Marketplace.reset())
 
 describe("server.routes.marketplace", () => {
   test("returns built-in capabilities", async () => {
@@ -11,5 +14,36 @@ describe("server.routes.marketplace", () => {
 
     expect(capabilities.status).toBe(200)
     expect(body.data.length).toBeGreaterThan(0)
+  })
+
+  test("persists enabled state through marketplace reads", async () => {
+    const app = Server.App()
+    const enabled = await app.request("http://railwise.test/marketplace/capabilities/railwise.mcp.local_tools/enable", {
+      method: "POST",
+    })
+    const detail = await app.request("http://railwise.test/marketplace/capabilities/railwise.mcp.local_tools")
+    const list = await app.request("http://railwise.test/marketplace/capabilities")
+    const item = (await detail.json()) as { enabled: boolean }
+    const body = (await list.json()) as { data: { id: string; enabled: boolean }[] }
+
+    expect(enabled.status).toBe(200)
+    expect(item.enabled).toBe(true)
+    expect(body.data.find((item) => item.id === "railwise.mcp.local_tools")?.enabled).toBe(true)
+  })
+
+  test("enabled marketplace capabilities change harness capacity", async () => {
+    const app = Server.App()
+    const before = await app.request("http://railwise.test/harness/status")
+    const base = (await before.json()) as { capabilityCount: number }
+
+    await app.request("http://railwise.test/marketplace/capabilities/railwise.mcp.local_tools/enable", {
+      method: "POST",
+    })
+
+    const after = await app.request("http://railwise.test/harness/status")
+    const current = (await after.json()) as { capabilityCount: number }
+
+    expect(after.status).toBe(200)
+    expect(current.capabilityCount).toBe(base.capabilityCount + 1)
   })
 })

--- a/packages/railwise/test/session/prompt-tools.test.ts
+++ b/packages/railwise/test/session/prompt-tools.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, spyOn, test } from "bun:test"
+import { jsonSchema, tool } from "ai"
+import { Agent } from "../../src/agent/agent"
+import { Marketplace } from "../../src/marketplace"
+import { MCP } from "../../src/mcp"
+import { Instance } from "../../src/project/instance"
+import type { Provider } from "../../src/provider/provider"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { tmpdir } from "../fixture/fixture"
+
+const model: Provider.Model = {
+  id: "test-model",
+  providerID: "railwise",
+  api: {
+    id: "test-model",
+    npm: "@ai-sdk/openai-compatible",
+    url: "https://example.invalid/v1",
+  },
+  name: "Test Model",
+  capabilities: {
+    temperature: true,
+    reasoning: false,
+    attachment: true,
+    toolcall: true,
+    input: {
+      text: true,
+      audio: false,
+      image: true,
+      video: false,
+      pdf: true,
+    },
+    output: {
+      text: true,
+      audio: false,
+      image: false,
+      video: false,
+      pdf: false,
+    },
+    interleaved: false,
+  },
+  cost: {
+    input: 0,
+    output: 0,
+    cache: {
+      read: 0,
+      write: 0,
+    },
+  },
+  limit: {
+    context: 128_000,
+    output: 16_000,
+  },
+  status: "active",
+  options: {},
+  headers: {},
+  release_date: "2026-01-01",
+}
+
+describe("session.prompt marketplace tools", () => {
+  test("desktop only injects MCP tools after local tools are enabled", async () => {
+    const client = process.env.RAILWISE_CLIENT
+    process.env.RAILWISE_CLIENT = "desktop"
+    await Marketplace.reset()
+
+    const mcp = spyOn(MCP, "tools").mockImplementation(async () => ({
+      railwise_external: tool({
+        description: "External MCP tool",
+        inputSchema: jsonSchema({ type: "object", properties: {} }),
+        async execute() {
+          return {
+            content: [{ type: "text" as const, text: "ok" }],
+          }
+        },
+      }),
+    }))
+
+    try {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await Session.create({})
+          const agent = await Agent.get("build")
+          const processor = {
+            message: {
+              id: "msg_test",
+              sessionID: session.id,
+              role: "assistant" as const,
+              parentID: "msg_parent",
+              modelID: model.id,
+              providerID: model.providerID,
+              mode: "build",
+              agent: agent.name,
+              path: {
+                cwd: tmp.path,
+                root: tmp.path,
+              },
+              cost: 0,
+              tokens: {
+                input: 0,
+                output: 0,
+                reasoning: 0,
+                cache: {
+                  read: 0,
+                  write: 0,
+                },
+              },
+              time: {
+                created: Date.now(),
+              },
+            },
+            partFromToolCall: () => undefined,
+            async process() {
+              throw new Error("unused")
+            },
+          } as unknown as Parameters<typeof SessionPrompt.resolveTools>[0]["processor"]
+
+          const hidden = await SessionPrompt.resolveTools({
+            agent,
+            model,
+            session,
+            processor,
+            bypassAgentCheck: false,
+            messages: [],
+          })
+
+          expect(hidden.railwise_external).toBeUndefined()
+          expect(mcp).toHaveBeenCalledTimes(0)
+
+          await Marketplace.setEnabled("railwise.mcp.local_tools", true)
+
+          const visible = await SessionPrompt.resolveTools({
+            agent,
+            model,
+            session,
+            processor,
+            bypassAgentCheck: false,
+            messages: [],
+          })
+
+          expect(visible.railwise_external).toBeDefined()
+          expect(mcp).toHaveBeenCalledTimes(1)
+        },
+      })
+    } finally {
+      mcp.mockRestore()
+      await Marketplace.reset()
+      if (client === undefined) delete process.env.RAILWISE_CLIENT
+      else process.env.RAILWISE_CLIENT = client
+    }
+  })
+})

--- a/packages/railwise/test/tool/registry.test.ts
+++ b/packages/railwise/test/tool/registry.test.ts
@@ -4,6 +4,7 @@ import fs from "fs/promises"
 import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { ToolRegistry } from "../../src/tool/registry"
+import { Marketplace } from "../../src/marketplace"
 
 describe("tool.registry", () => {
   test("loads tools from .railwise/tool (singular)", async () => {
@@ -118,5 +119,36 @@ describe("tool.registry", () => {
         expect(ids).toContain("cowsay")
       },
     })
+  })
+
+  test("desktop tools follow marketplace local capability toggles", async () => {
+    const client = process.env.RAILWISE_CLIENT
+    process.env.RAILWISE_CLIENT = "desktop"
+    await Marketplace.reset()
+    await using tmp = await tmpdir()
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ids = await ToolRegistry.ids()
+
+          expect(ids).toContain("read")
+          expect(ids).not.toContain("bash")
+          expect(ids).not.toContain("write")
+
+          await Marketplace.setEnabled("railwise.mcp.local_tools", true)
+
+          const next = await ToolRegistry.ids()
+
+          expect(next).toContain("bash")
+          expect(next).toContain("write")
+        },
+      })
+    } finally {
+      if (client === undefined) delete process.env.RAILWISE_CLIENT
+      else process.env.RAILWISE_CLIENT = client
+      await Marketplace.reset()
+    }
   })
 })


### PR DESCRIPTION
## Summary
- align Desktop docs with the Workbench-first, Harness, and Marketplace product scope
- retarget startup performance and settings E2E coverage from /agents to /home
- add Workbench navigation coverage for Marketplace and Harness with deterministic desktop E2E fixtures

## Verification
- cd packages/desktop && bun run typecheck
- git diff --check
- cd packages/app && bun test --preload ./happydom.ts ./src/pages/marketplace/marketplace-state.test.ts ./src/components/harness-timeline.test.tsx
- cd packages/railwise && bun test test/harness/schema.test.ts test/marketplace/service.test.ts test/server/harness.test.ts test/server/marketplace.test.ts --timeout 30000
- cd packages/desktop && bun run build
- git push pre-push hook: bun turbo typecheck passed (12 packages)

Note: targeted desktop Playwright E2E could not start in this sandbox because local TCP port binding is denied (Python socket bind returns Operation not permitted).