### PR TITLE
fix(installer): support `--target custom --dest <path>`

### DIFF
--- a/skill-pack-template/bin/install.js
+++ b/skill-pack-template/bin/install.js
@@ -31,22 +31,27 @@ function custom(target) {
   return target.startsWith(".") || target.startsWith("~") || target.includes("/")
 }
 
+function customCtx(root) {
+  return {
+    name: "custom",
+    root,
+    layout: {
+      agent: "agent",
+      skill: "skill",
+      command: "command",
+      tool: "tool",
+      template: "templates",
+      theme: "themes",
+    },
+  }
+}
+
 function target(name) {
   const value = name || "railwise"
-  if (custom(value)) {
-    return {
-      name: "custom",
-      root: home(value),
-      layout: {
-        agent: "agent",
-        skill: "skill",
-        command: "command",
-        tool: "tool",
-        template: "templates",
-        theme: "themes",
-      },
-    }
-  }
+  const dest = option("--dest")
+  if (dest) return customCtx(home(dest))
+  if (value === "custom") throw new Error("Target 'custom' requires --dest <path>")
+  if (custom(value)) return customCtx(home(value))
   if (value === "codex") {
     return {
       name: value,


### PR DESCRIPTION
## Summary

Follow-up to #65. While smoke-testing the agent pack via the advertised `npx github:railwise-cn/railwise-agent-pack install --target custom --dest <path>` flow, the install **failed** with `Unknown target: custom`.

## Root cause

`skill-pack-template/bin/install.js` decided "is this a custom path?" purely by inspecting the `--target` string (absolute / starts with `.` / `~` / contains `/`). The literal keyword `custom` matched none of those, fell through every named target, and threw. The `--dest` option documented in the pack README was never read.

## Fix

- `--dest <path>` now selects a custom root (with or without `--target custom`).
- A bare `--target custom` without `--dest` throws a clear, actionable error.
- The existing path shorthand (`--target ./dir`, `--target /abs`, `--target ~/x`) and named targets (`codex`/`claude`/`opencode`/`railwise`) are unchanged.
- Extracted the shared custom-layout into a small `customCtx()` helper (no duplication).

## Verification

Ran the built pack's installer across every path:

| Scenario | Result |
| --- | --- |
| `install --target custom --dest /tmp/x --force` | ✅ 65 assets written |
| `install --target custom` (no `--dest`) | ✅ clear error |
| `install --target /tmp/x --force` (shorthand) | ✅ still works |
| `install --target codex --dry-run` | ✅ correct `~/.codex/...` paths |
| `where --target custom --dest /tmp/foo` | ✅ correct paths |
| `list` | ✅ 65 assets |

The same fix has been propagated to the published **railwise-cn/railwise-agent-pack** repo so `npx github:` works immediately.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>