### PR TITLE
fix(release): make shared-package publish pipeline coherent and npm-safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ tmp
 railwise-agent-pack
 dist
 ts-dist
+*.tgz
 .turbo
 **/.serena
 .serena/

--- a/packages/sdk/js/script/publish.ts
+++ b/packages/sdk/js/script/publish.ts
@@ -2,14 +2,30 @@
 
 import { Script } from "@railwise/script"
 import { $ } from "bun"
+import { cp } from "node:fs/promises"
+import path from "node:path"
+
+const args = Bun.argv.slice(2)
+const flag = (name: string) => args.includes(name)
+const arg = (name: string) => {
+  const index = args.indexOf(name)
+  if (index === -1) return undefined
+  return args[index + 1]
+}
+const dry = flag("--dry-run")
+const packOnly = flag("--pack-only")
+const out = arg("--out")
 
 const dir = new URL("..", import.meta.url).pathname
 process.chdir(dir)
 
 const pkg = (await import("../package.json").then((m) => m.default)) as {
+  name: string
+  version: string
   exports: Record<string, string | object>
 }
 const original = JSON.parse(JSON.stringify(pkg))
+const version = process.env.RAILWISE_VERSION || pkg.version
 function transformExports(exports: Record<string, string | object>) {
   for (const [key, value] of Object.entries(exports)) {
     if (typeof value === "object" && value !== null) {
@@ -24,7 +40,13 @@ function transformExports(exports: Record<string, string | object>) {
   }
 }
 transformExports(pkg.exports)
-await Bun.write("package.json", JSON.stringify(pkg, null, 2))
+pkg.version = version
+await Bun.write("package.json", JSON.stringify(pkg, null, 2) + "\n")
 await $`bun pm pack`
-await $`npm publish *.tgz --tag ${Script.channel} --access public`
-await Bun.write("package.json", JSON.stringify(original, null, 2))
+const tarball = `${pkg.name.replace(/^@/, "").replace("/", "-")}-${version}.tgz`
+if (out) await cp(tarball, path.join(out, tarball))
+if (!packOnly)
+  await (dry
+    ? $`npm publish ${tarball} --tag ${Script.channel} --access public --dry-run`
+    : $`npm publish ${tarball} --tag ${Script.channel} --access public`)
+await Bun.write("package.json", JSON.stringify(original, null, 2) + "\n")

--- a/scripts/pack-shared-packages.ts
+++ b/scripts/pack-shared-packages.ts
@@ -23,7 +23,7 @@ const dirs = ["packages/util", "packages/ui", "packages/app"]
 const rootpkg = await Bun.file("package.json").json()
 const catalog = (rootpkg.workspaces as { catalog?: Record<string, string> }).catalog ?? {}
 const { Script } = await import("@railwise/script")
-const version = Script.version
+const version = Script.version.replace(/[^0-9A-Za-z.-]/g, "-")
 process.env.RAILWISE_VERSION = version
 
 function file(name: string) {

--- a/scripts/publish-shared-packages.ts
+++ b/scripts/publish-shared-packages.ts
@@ -28,29 +28,31 @@ if (args.includes("--help")) {
 }
 
 const { Script } = await import("@railwise/script")
-process.env.RAILWISE_VERSION = Script.version
+const version = Script.version.replace(/[^0-9A-Za-z.-]/g, "-")
+const channel = Script.channel.replace(/[^0-9A-Za-z.-]/g, "-")
+process.env.RAILWISE_VERSION = version
 
-function dep(name: string, version: string) {
-  if (version === "workspace:*") return Script.version
-  if (version === "catalog:") {
-    const value = catalog[name]
-    if (!value) throw new Error(`Missing catalog version for ${name}`)
-    return value
+function dep(name: string, value: string) {
+  if (value === "workspace:*") return version
+  if (value === "catalog:") {
+    const found = catalog[name]
+    if (!found) throw new Error(`Missing catalog version for ${name}`)
+    return found
   }
-  return version
+  return value
 }
 
 function deps(value: unknown) {
   if (!value || typeof value !== "object") return undefined
   return Object.fromEntries(
-    Object.entries(value as Record<string, string>).map(([name, version]) => [name, dep(name, version)]),
+    Object.entries(value as Record<string, string>).map(([name, value]) => [name, dep(name, value)]),
   )
 }
 
 async function write(pkg: Json, dir: string) {
   const next = { ...pkg }
   delete next.private
-  next.version = Script.version
+  next.version = version
   next.dependencies = deps(next.dependencies)
   next.devDependencies = deps(next.devDependencies)
   next.peerDependencies = deps(next.peerDependencies)
@@ -78,8 +80,8 @@ await (dry ? $`bun ./packages/sdk/js/script/publish.ts --dry-run` : $`bun ./pack
 for (const dir of dirs) {
   await $`bun pm pack`.cwd(path.join(pack, dir))
   await (dry
-    ? $`npm publish *.tgz --access public --tag ${Script.channel} --dry-run`.cwd(path.join(pack, dir))
-    : $`npm publish *.tgz --access public --tag ${Script.channel}`.cwd(path.join(pack, dir)))
+    ? $`npm publish *.tgz --access public --tag ${channel} --dry-run`.cwd(path.join(pack, dir))
+    : $`npm publish *.tgz --access public --tag ${channel}`.cwd(path.join(pack, dir)))
 }
 
 console.log("shared package publish complete")


### PR DESCRIPTION
## Summary

While validating the shared-package publish pipeline (`pack:shared` / `publish:shared`) end-to-end, I found it would **crash on any feature branch** and produce an **incoherent package set**. This PR fixes both so the pipeline matches the behavior already documented in `docs/dev/decoupled-release.md`.

### Bugs found

1. **`publish.ts` ignored its flags + the version its callers set.** The SDK `publish.ts` ran a live `npm publish` regardless of `--pack-only` / `--dry-run`, so `publish:shared` (dry-run by default) would publish for real. It also ignored the `RAILWISE_VERSION` that both shared scripts explicitly set, so the SDK packed at its own `package.json` version (`1.2.8`) while `util`/`ui`/`app` used `Script.version`. That broke the `workspace:*` → version dependency rewrite and the manifest's SDK entry (manifest pointed at a tarball that didn't exist).
2. **Branch names leaked into versions/tags.** `Script.version`/`Script.channel` embed the raw git branch, so `fix/foo` produced `0.0.0-fix/foo-<ts>` — invalid semver, an invalid npm dist-tag, and a `/` that broke `bun pm pack` tarball paths.

### Fixes

- **`packages/sdk/js/script/publish.ts`**: honor `--pack-only`, `--out <dir>`, `--dry-run`, and `RAILWISE_VERSION || pkg.version`; stamp the effective version into the packed `package.json`; restore `package.json` with a trailing newline (no spurious diff).
- **`scripts/pack-shared-packages.ts` / `scripts/publish-shared-packages.ts`**: normalize the preview version **and** npm dist-tag to npm-safe characters (`[^0-9A-Za-z.-]` → `-`). This is the normalization `decoupled-release.md` already promised.
- **`.gitignore`**: ignore generated `*.tgz` artifacts.

### Backward compatibility

The default (no-flag) `publish.ts` path is unchanged, and the CI release path is unaffected: root `script/publish.ts` stamps every `package.json` to `Script.version` *before* publishing, and `publish.yml` sets `RAILWISE_VERSION=''` (empty string falls back via `||`).

### Validation

- `bun run pack:shared` → `dist/shared-packages/` with `manifest.json` + **4 coherent tgz** (sdk/util/ui/app all at one version); `app`'s `@railwise/{sdk,ui,util}` deps all pinned to that same version; no `workspace:*`/`catalog:` leaks.
- `bun run publish:shared` → `npm publish --dry-run` with tag `fix-sdk-publish-pack-only` (sanitized), **no live publish**.
- `bun turbo typecheck --filter=@railwise/sdk` passes; working tree left clean (SDK `package.json` restores byte-for-byte).

> Note: a real publish (`publish:shared --publish`) still requires `npm login` — the current `~/.npmrc` token returns 401. Out of scope for this PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>