### PR TITLE
ci(release): add manual publish-shared workflow

### DIFF
--- a/.github/workflows/publish-shared.yml
+++ b/.github/workflows/publish-shared.yml
@@ -1,0 +1,52 @@
+name: publish-shared
+run-name: "publish-shared ${{ inputs.version || 'from .cli-version' }} ${{ inputs.dry_run && '(dry-run)' || '(publish)' }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (defaults to packages/desktop/.cli-version)"
+        required: false
+        type: string
+      dry_run:
+        description: "Dry run only (no real npm publish)"
+        required: false
+        default: true
+        type: boolean
+
+concurrency: ${{ github.workflow }}
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'railwise-cn/RAILWISE-CLI'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-bun
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Resolve version
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [ -z "$VERSION" ]; then VERSION="$(cat packages/desktop/.cli-version)"; fi
+          echo "RAILWISE_VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "Publishing shared packages at version $VERSION (dry_run=${{ inputs.dry_run }})"
+
+      - name: Publish shared packages
+        run: bun run publish:shared ${{ !inputs.dry_run && '-- --publish' || '' }}
+        env:
+          RAILWISE_CHANNEL: latest
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: false

--- a/docs/dev/decoupled-release.md
+++ b/docs/dev/decoupled-release.md
@@ -53,6 +53,15 @@ The script defaults to npm `--dry-run`. CI must pass `--publish` for a real publ
 
 Published package versions should match the CLI version that generated the SDK.
 
+### Publishing from CI (recommended)
+
+The `publish-shared` workflow (`.github/workflows/publish-shared.yml`) publishes the shared packages using the repository's `NPM_TOKEN` secret, so no local `npm login` is required. Trigger it from the Actions tab (`workflow_dispatch`):
+
+- `version` — the version to publish. Defaults to `packages/desktop/.cli-version` so the shared packages line up with the pinned CLI.
+- `dry_run` — defaults to `true` (runs `npm publish --dry-run`). Set it to `false` to perform a real publish.
+
+The workflow sets `RAILWISE_CHANNEL=latest`, so released packages are tagged `latest`. Run it once with `dry_run=true` to verify the staged tarballs, then re-run with `dry_run=false` to publish.
+
 ## Desktop Split
 
 Export a standalone Desktop repository snapshot:


### PR DESCRIPTION
## Summary

Wires the existing (and now dry-run-validated) `publish:shared` script into CI via a **manually triggered** workflow, so the shared frontend packages can be published to npm using the repo's `NPM_TOKEN` secret — **no local `npm login` required**.

This satisfies the Desktop split precondition (shared packages on npm) without exposing credentials locally, and is the recommended path going forward.

## Behavior

`.github/workflows/publish-shared.yml` — `workflow_dispatch` only (never runs automatically):

| Input | Default | Effect |
|-------|---------|--------|
| `version` | `packages/desktop/.cli-version` (`1.2.8`) | Version to publish; keeps shared packages aligned with the pinned CLI |
| `dry_run` | `true` | `npm publish --dry-run`; set to `false` for a real publish |

- Sets `RAILWISE_CHANNEL=latest` so released packages are tagged `latest`.
- Gated with `if: github.repository == 'railwise-cn/RAILWISE-CLI'`.
- Publishes `@railwise/{sdk,util,ui,app}` as a coherent set at one version (via the version-coherence fix merged in #67).

## Recommended usage

1. Dispatch with `dry_run=true` (default) to verify the staged tarballs.
2. Re-run with `dry_run=false` to publish for real.

> First real publish requires the `NPM_TOKEN` secret to be set and the `@railwise` npm scope to be owned by the team (today `@railwise/sdk` returns "Not Found" on npm — these would be first-time publishes).

## Notes

- Safe to land: this only runs when a human dispatches it.
- The `publish:shared` script itself was validated end-to-end in dry-run in #67 (coherent versions, correct dependency rewrites, sanitized npm dist-tag, no live publish).
- Documented in `docs/dev/decoupled-release.md`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>